### PR TITLE
[FEAT] 데이터베이스 구현

### DIFF
--- a/Maddori.Apple-Server/models/css.js
+++ b/Maddori.Apple-Server/models/css.js
@@ -2,14 +2,14 @@
 const { Model } = require("sequelize");
 
 module.exports = function(sequelize, DataTypes){
-    class reflection extends Model {
+    class css extends Model {
         
         static associate(models) {
 
         }
     }
 
-    reflection.init(
+    css.init(
         {
             id: {
                 field: "id",
@@ -17,25 +17,36 @@ module.exports = function(sequelize, DataTypes){
                 primaryKey: true,
                 autoIncrement: true
             },
-            reflection_name: {
-                field: "reflection_name",
+            type: {
+                field: "type",
+                type: DataTypes.ENUM("Continue", "Stop"),
+                allowNull: false,
+                defaultValue: "Continue"
+            },
+            keyword: {
+                field: "keyword",
                 type: DataTypes.STRING(15),
                 allowNull: false
             },
-            date: {
-                field: "date",
-                type: DataTypes.DATE,
+            content: {
+                field: "content",
+                type: DataTypes.STRING(200),
                 allowNull: true
             },
-            state: {
-                field: "state",
-                type: DataTypes.ENUM("SettingRequired", "Before", "Progressing", "Done"),
+            is_favorite: {
+                field: "is_favorite",
+                type: DataTypes.BOOLEAN,
                 allowNull: false,
-                defaultValue: "SettingRequired"
+                defaultValue: false
+            },
+            start_content: {
+                field: "start_content",
+                type: DataTypes.STRING(200),
+                allowNull: true
             }
         }, {
             sequelize,
-            modelName: "reflection",
+            modelName: "css",
             timestamps: false,
             freezeTableName: true,
             charset: "utf8",
@@ -43,5 +54,5 @@ module.exports = function(sequelize, DataTypes){
             underscored: true
         }
     );
-    return reflection;
+    return css;
 }

--- a/Maddori.Apple-Server/models/css.js
+++ b/Maddori.Apple-Server/models/css.js
@@ -5,7 +5,22 @@ module.exports = function(sequelize, DataTypes){
     class css extends Model {
         
         static associate(models) {
-
+            css.belongsTo(models.user, {
+                foreignKey: {
+                    name: 'from_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            }),
+            css.belongsTo(models.user, {
+                foreignKey: {
+                    name: 'to_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            })
         }
     }
 

--- a/Maddori.Apple-Server/models/css.js
+++ b/Maddori.Apple-Server/models/css.js
@@ -20,6 +20,14 @@ module.exports = function(sequelize, DataTypes){
                 },
                 onDelete: 'CASCADE',
                 hooks: true
+            }),
+            css.belongsTo(models.team, {
+                foreignKey: {
+                    name: 'team_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
             })
         }
     }

--- a/Maddori.Apple-Server/models/css.js
+++ b/Maddori.Apple-Server/models/css.js
@@ -28,6 +28,14 @@ module.exports = function(sequelize, DataTypes){
                 },
                 onDelete: 'CASCADE',
                 hooks: true
+            }),
+            css.belongsTo(models.reflection, {
+                foreignKey: {
+                    name: 'reflection_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
             })
         }
     }

--- a/Maddori.Apple-Server/models/reflection.js
+++ b/Maddori.Apple-Server/models/reflection.js
@@ -26,6 +26,14 @@ module.exports = function(sequelize, DataTypes){
                     name: 'recent_reflection_id',
                     allowNull: true
                 },
+            }),
+            reflection.hasMany(models.css, {
+                foreignKey: {
+                    name: 'reflection_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
             })
         }
     }

--- a/Maddori.Apple-Server/models/reflection.js
+++ b/Maddori.Apple-Server/models/reflection.js
@@ -1,11 +1,32 @@
 'use strict';
 const { Model } = require("sequelize");
 
+
+// TODO: reflection 삭제 시 current_reflection_id가 연관된 team 삭제되지 않도록 수정
 module.exports = function(sequelize, DataTypes){
     class reflection extends Model {
         
         static associate(models) {
-
+            reflection.belongsTo(models.team, {
+                foreignKey: {
+                    name: 'team_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            }),
+            reflection.hasOne(models.team, {
+                foreignKey: {
+                    name: 'current_reflection_id',
+                    allowNull: false
+                },
+            }),
+            reflection.hasOne(models.team, {
+                foreignKey: {
+                    name: 'recent_reflection_id',
+                    allowNull: true
+                },
+            })
         }
     }
 

--- a/Maddori.Apple-Server/models/reflection.js
+++ b/Maddori.Apple-Server/models/reflection.js
@@ -1,0 +1,48 @@
+'use strict';
+const { Model } = require("sequelize");
+// user 테이블 만들어서 User 객체로 저장하기
+
+module.exports = function(sequelize, DataTypes){
+    class reflection extends Model {
+        
+        static associate(models) {
+
+        }
+    }
+
+    reflection.init(
+        {
+            id: {
+                field: "id",
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            reflection_name: {
+                field: "reflection_name",
+                type: DataTypes.STRING(15),
+                allowNull: false
+            },
+            date: {
+                field: "date",
+                type: DataTypes.DATE,
+                allowNull: true
+            },
+            state: {
+                field: "state",
+                type: DataTypes.ENUM("SettingRequired", "Before", "Progressing", "Done"),
+                allowNull: false,
+                defaultValue: "SettingRequired"
+            }
+        }, {
+            sequelize,
+            modelName: "reflection",
+            timestamps: false,
+            freezeTableName: true,
+            charset: "utf8",
+            collate: "utf8_general_ci",
+            underscored: true
+        }
+    );
+    return reflection;
+}

--- a/Maddori.Apple-Server/models/team.js
+++ b/Maddori.Apple-Server/models/team.js
@@ -3,8 +3,43 @@ const { Model } = require("sequelize");
 
 module.exports = function(sequelize, DataTypes){
     class team extends Model {
-        
         static associate(models) {
+            models.team.hasMany(models.userteam, {
+                foreignKey: {
+                    name: 'team_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            }),
+            models.team.hasMany(models.css, {
+                foreignKey: {
+                    name: 'team_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            }),
+            models.team.hasMany(models.reflection, {
+                foreignKey: {
+                    name: 'team_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            }),
+            models.team.belongsTo(models.reflection, {
+                foreignKey: {
+                    name: 'current_reflection_id',
+                    allowNull: false
+                },
+            }),
+            models.team.belongsTo(models.reflection, {
+                foreignKey: {
+                    name: 'recent_reflection_id',
+                    allowNull: true
+                },
+            })
 
         }
     }

--- a/Maddori.Apple-Server/models/team.js
+++ b/Maddori.Apple-Server/models/team.js
@@ -1,6 +1,5 @@
 'use strict';
 const { Model } = require("sequelize");
-// user 테이블 만들어서 User 객체로 저장하기
 
 module.exports = function(sequelize, DataTypes){
     class team extends Model {

--- a/Maddori.Apple-Server/models/team.js
+++ b/Maddori.Apple-Server/models/team.js
@@ -1,0 +1,42 @@
+'use strict';
+const { Model } = require("sequelize");
+// user 테이블 만들어서 User 객체로 저장하기
+
+module.exports = function(sequelize, DataTypes){
+    class team extends Model {
+        
+        static associate(models) {
+
+        }
+    }
+
+    team.init(
+        {
+            id: {
+                field: "id",
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            team_name: {
+                field: "team_name",
+                type: DataTypes.STRING(10),
+                allowNull: false
+            },
+            invitation_code: {
+                field: "invitation_code",
+                type: DataTypes.STRING(6),
+                allowNull: false
+            }
+        }, {
+            sequelize,
+            modelName: "team",
+            timestamps: false,
+            freezeTableName: true,
+            charset: "utf8",
+            collate: "utf8_general_ci",
+            underscored: true
+        }
+    );
+    return team;
+}

--- a/Maddori.Apple-Server/models/user.js
+++ b/Maddori.Apple-Server/models/user.js
@@ -1,0 +1,40 @@
+'use strict';
+const { Model } = require("sequelize");
+// user 테이블 만들어서 User 객체로 저장하기
+
+module.exports = function(sequelize, DataTypes){
+    class user extends Model {
+        
+        static associate(models) {
+            // define association here
+            // models.user.hasMany(models.userteam, {
+            //     onDelete: 'CASCADE'
+            // });
+        }
+    }
+
+    user.init(
+        {
+            id: {
+                field: "id",
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            username: {
+                field: "username",
+                type: DataTypes.STRING(6),
+                allowNull: false
+            }
+        }, {
+            sequelize,
+            modelName: "user",
+            timestamps: false,
+            freezeTableName: true,
+            charset: "utf8",
+            collate: "utf8_general_ci",
+            underscored: true
+        }
+    );
+    return user;
+}

--- a/Maddori.Apple-Server/models/user.js
+++ b/Maddori.Apple-Server/models/user.js
@@ -1,15 +1,33 @@
 'use strict';
 const { Model } = require("sequelize");
-// user 테이블 만들어서 User 객체로 저장하기
 
 module.exports = function(sequelize, DataTypes){
-    class user extends Model {
-        
+    class user extends Model { 
         static associate(models) {
-            // define association here
-            // models.user.hasMany(models.userteam, {
-            //     onDelete: 'CASCADE'
-            // });
+            models.user.hasMany(models.userteam, {
+                foreignKey: {
+                    name: 'user_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            })
+            models.user.hasMany(models.css, {
+                foreignKey: {
+                    name: 'from_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            }),
+            models.user.hasMany(models.css, {
+                foreignKey: {
+                    name: 'to_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            })
         }
     }
 

--- a/Maddori.Apple-Server/models/userteam.js
+++ b/Maddori.Apple-Server/models/userteam.js
@@ -11,6 +11,14 @@ module.exports = function(sequelize, DataTypes){
                 },
                 onDelete: 'CASCADE',
                 hooks: true
+            }),
+            userteam.belongsTo(models.team, {
+                foreignKey: {
+                    name: 'team_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
             })
         }
     }

--- a/Maddori.Apple-Server/models/userteam.js
+++ b/Maddori.Apple-Server/models/userteam.js
@@ -1,0 +1,42 @@
+'use strict';
+const { Model } = require("sequelize");
+// user 테이블 만들어서 User 객체로 저장하기
+
+module.exports = function(sequelize, DataTypes){
+    class userteam extends Model {
+        
+        // static associate(models) {
+        //     // define association here
+        //     UserTeam.belongsTo(models.User, {
+        //         foreignKey: 'user_id',
+        //         onDelete: 'CASCADE'
+        //     })
+        // }
+    }
+
+    userteam.init(
+        {
+        id: {
+            field: "id",
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        admin: {
+            field: "admin",
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
+        }, {
+            sequelize,
+            modelName: "userteam",
+            timestamps: false,
+            freezeTableName: true,
+            charset: "utf8",
+            collate: "utf8_general_ci",
+            underscored: true
+        }
+    );
+    return userteam;
+}

--- a/Maddori.Apple-Server/models/userteam.js
+++ b/Maddori.Apple-Server/models/userteam.js
@@ -1,6 +1,5 @@
 'use strict';
 const { Model } = require("sequelize");
-// user 테이블 만들어서 User 객체로 저장하기
 
 module.exports = function(sequelize, DataTypes){
     class userteam extends Model {

--- a/Maddori.Apple-Server/models/userteam.js
+++ b/Maddori.Apple-Server/models/userteam.js
@@ -3,14 +3,16 @@ const { Model } = require("sequelize");
 
 module.exports = function(sequelize, DataTypes){
     class userteam extends Model {
-        
-        // static associate(models) {
-        //     // define association here
-        //     UserTeam.belongsTo(models.User, {
-        //         foreignKey: 'user_id',
-        //         onDelete: 'CASCADE'
-        //     })
-        // }
+        static associate(models) {
+            userteam.belongsTo(models.user, {
+                foreignKey: {
+                    name: 'user_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            })
+        }
     }
 
     userteam.init(


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
아래 erd 기준으로 데이터베이스를 구현했습니다
<img width="894" alt="version4" src="https://user-images.githubusercontent.com/67336936/197400902-8d807e7e-eb2c-4596-a44a-4f4be61e2290.png">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 데이터베이스 생성
- 테이블 생성 (user, userteam, team, reflection, css)
- 테이블간 연관관계 설정 (외래키 설정)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 해보고 싶으신게 있다면 찾아와주세요

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="653" alt="디비구현결과" src="https://user-images.githubusercontent.com/67336936/197400971-6853a1f5-aea8-40fb-ada9-47e3e9d11f14.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- on delete : cascade 를 사용하였습니다
  1:N 관계에 있는 테이블에서 1쪽의 데이터가 사라지면 N쪽의 데이터도 사라지게 하는 설정입니다.
  ex) 팀 테이블에 있는 '맛사' 팀, 회고 테이블에 있는 맛사 팀이 진행 중인 '첫번째 스프린트' 가 있다면
        '맛사' 팀 정보가 삭제되었을 때 '첫번째 스프린트' 데이터도 삭제되게 구현하였습니다.

  일단 모든 1:N 관계를 가진 곳에서 설정을 부여하였는데, 아래와 같은 상황 때문에 어떤 부분에 이 설정을 부여하는게 좋을지 추후에 함께 논의해봐야할 것 같아요! ↓
  🤔 지금은 유저 테이블(1) - css 테이블(N) 형태로 구현되어있는데, 이렇게 되면 유저가 삭제될 때 해당 유저가 작성한 css 내용도 함께 삭제되게 됩니다. 그럼 그 css를 받았던 유저는 더 이상 해당 css를 확인할 수 없게 돼요!

- null 허용
  위에 스크린샷에서 Null : YES 라고 되어있는 부분은 Null 값을 허용하는 필드입니다!
  제 기준으로 판단했을 때 Null 값이 있어도 되는 부분만 Null 값 허용 처리 해줬는데, 틀렸을 수도 있으니깐 혹시 틀린 부분 눈에 보이시면 알려주세요🥲


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #7 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://sequelize.org/docs/v7/core-concepts/assocs/