### PR TITLE
[FEAT] Home View api 구현 - 팀 정보, 현재 회고 정보

### DIFF
--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    getRelfectionInformation
+    getReflectionInformation
 } = require('./reflections');
 
-router.get('/current', getRelfectionInformation);
+router.get('/current', getReflectionInformation);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -1,5 +1,9 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
+const {
+    getRelfectionInformation
+} = require('./reflections');
 
+router.get('/current', getRelfectionInformation);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -3,7 +3,7 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // request data : user_id, team_id
 // response data : current_reflection_id, reflection_name, date, status, 회고에 속한 keywords 목록
 // 팀에서 진행하는 현재의 회고 정보 가져오기
-async function getRelfectionInformation(req, res, next) {
+async function getReflectionInformation(req, res, next) {
     console.log("현재 회고 정보 가져오기");
 
     try {
@@ -40,5 +40,5 @@ async function getRelfectionInformation(req, res, next) {
 }
 
 module.exports = {
-    getRelfectionInformation
+    getReflectionInformation
 };

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -1,0 +1,44 @@
+const {user, team, userteam, reflection, feedback} = require('../../models');
+
+// request data : user_id, team_id
+// response data : current_reflection_id, reflection_name, date, status, 회고에 속한 keywords 목록
+// 팀에서 진행하는 현재의 회고 정보 가져오기
+async function getRelfectionInformation(req, res, next) {
+    console.log("현재 회고 정보 가져오기");
+
+    try {
+        // 팀의 현재 회고 id
+        const currentReflectionId = await team.findByPk(req.params.team_id, {
+            attributes: ['current_reflection_id'],
+            raw : true
+        });
+        // 팀의 현재 회고의 reflection_name, date, status
+        const reflectionInformation = await reflection.findByPk(currentReflectionId.current_reflection_id);
+        // 팀의 현재 회고에 속한 keywords
+        const keywordsList = await feedback.findAll({
+            attributes: ['keyword'],
+            where: {
+                reflection_id: currentReflectionId.current_reflection_id
+            },
+            raw : true
+        });
+        console.log(keywordsList);
+        // 위 데이터 중 필요한 부분을 합친 response 데이터 만들기
+        const reflectionFinalInformation = {
+            current_reflection_id : currentReflectionId.current_reflection_id,
+            reflection_name : reflectionInformation.reflection_name,
+            reflection_date : reflectionInformation.date,
+            reflection_status : reflectionInformation.state,
+            reflection_keywords : keywordsList.map((data) => data.keyword)
+        }
+        res.status(200).json(reflectionFinalInformation);
+
+    } catch(error) {
+        // TODO: 에러 처리 수정
+        res.status(500).send(error);
+    }
+}
+
+module.exports = {
+    getRelfectionInformation
+};

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    createTeam
+    createTeam,
+    getTeamInformation
 } = require('./teams');
 
 router.post('/', createTeam);
+router.get('/:team_id', getTeamInformation);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -50,6 +50,14 @@ async function createTeam(req, res) {
         const createdReflection = await reflection.create({
             team_id: createdTeam.id
         });
+        // 현재 팀의 current_reflection_id 업데이트
+        const updatedTeam = await team.update({
+            current_reflection_id: createdReflection.id
+        }, {
+            where : {
+                id: createdTeam.id
+            }
+        });
         // 유저의 팀 합류 및 리더 설정
         const createdUserTeam = await userteam.create({
             user_id: req.header('user_id'),

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -63,6 +63,39 @@ async function createTeam(req, res) {
     }
 }
 
+// request data : user_id, team_id
+// response data : team_id, team_name, invitation_code, admin
+// 팀의 정보 가져오기
+async function getTeamInformation(req, res, next) {
+    console.log("팀의 정보 가져오기");
+
+    try {
+        // 팀의 team_name, invitation_code
+        const teamBasicInformation = await team.findByPk(req.params.team_id);
+        // 유저가 팀의 리더인지 확인
+        const teamLeader = await userteam.findOne({
+            where : {
+                user_id : req.header('user_id'),
+                team_id : req.params.team_id
+            },
+            raw : true
+        });
+        // 위 데이터 중 필요한 부분을 합친 response 데이터 만들기
+        const teamFinalInformation = {
+            team_id : req.params.team_id,
+            team_name : teamBasicInformation.team_name,
+            invitation_code : teamBasicInformation.invitation_code,
+            admin : teamLeader.admin
+        }
+        res.status(200).json(teamFinalInformation);
+
+    } catch(error) {
+        // TODO: 에러 처리 수정
+        res.status(500).send(error);
+    }
+}
+
 module.exports = {
-    createTeam
+    createTeam,
+    getTeamInformation
 };


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
Home View에서 사용하는 팀 정보 가져오기, 현재 회고 정보 가져오기 api를 구현하였습니다.
메인 화면을 구성하는 데이터를 위 두 api를 통해 가져올 수 있습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 팀 정보 가져오기
  team_id를 받아 id가 일치하는 팀이 있다면, team 테이블에서 데이터를 찾아 가져옵니다.
- 현재 회고 정보 가져오기
  team_id를 받아 id가 일치하는 팀이 있다면, team의 현재 회고 id를 가져옵니다. 해당 회고 id를 사용해 회고의 전체 정보, 회고에 등록된 키워드 리스트를 가져오게 됩니다.


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- **팀 정보 가져오기**
  URI : GET `/teams/{team_id}`
  request header : { "user_id" : "1" }

- **팀의 현재 회고 정보 가져오기**
  URI : GET `/teams/{team_id}/reflections/current`
  request header : { "user_id" : "1" }

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/199676509-15ec1a80-dd47-4422-8b1d-c9b06a433609.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/199676279-bd3626b9-0e87-44ea-babd-28f672f4064f.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 요청을 보내는 유저가 실제로 요청 대상 팀에 속해있는 멤버인지 검증하는 미들웨어 구현 후 코드 추가할 예정입니다
- 팀 정보 가져오기 request는 오로지 한 번만 수행해도 되는 반면, 팀의 현재 회고 정보는 데이터 변경이 일어날 수 있기에 뷰가 appear 될 때마다 현재 회고 정보를 가져오는 request를 보내야 합니다.
   따라서 팀 정보 가져오기 api와 팀 현재 회고 정보 가져오기 api를 구분했습니다. 혹시 위와 같은 구분이 필요하지 않다고 생각하시거나, 다른 의견 있으시면 제안해주세요!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #17 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
