### PR TITLE
[FEAT] 회고 목록 조회, 특정 타입 피드백 조회 api 구현

### DIFF
--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -56,19 +56,42 @@ const getCertainTypeFeedbackAll = async (req, res) => {
                     }
                 ]
             })  
-            return res.status(200).json({'success':true, 'message':'최근 회고 피드백 조회 성공','detail':feedbackData});         
+            return res.status(200).json({
+                'success':true,
+                'message':'최근 회고 피드백 조회 성공',
+                'detail': {
+                    "feedback": [feedbackData]
+                }
+            });         
         }
         const feedbackData = await feedback.findAll({
             where: {
                 team_id: team_id,
                 reflection_id: reflection_id,
                 type: type
-            }
+            },
+            include: [
+                {
+                    model: reflection, where: { id: recentReflectionId }
+                },
+                {
+                    model: user
+                }
+            ]
         })
-        return res.status(200).json({'success':true, 'message':'피드백 조회 성공','detail':feedbackData});
+        return res.status(200).json({
+            'success':true,
+            'message':'피드백 정보 조회 성공',
+            'detail': {
+                "feedback": [feedbackData]
+            }
+        });
     } catch (error) {
         console.log(error);
-        return res.status(400).json({"success":false, "message":"조회 실패"})
+        return res.status(400).json({
+            'success':false,
+            'message':'피드백 정보 조회 실패'
+        })
     }
 }
 

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -29,7 +29,8 @@ async function createFeedback(req, res, next) {
 }
 
 // request data: team_id, reflection_id, type
-// response data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
+// response data: id, type, keyword, content, start_content, from_id, to_id, 
+//team_id, reflection_id,reflection_name, 보내는 user_name
 // 특정 type을 만족하는 feedback을 불러온다.
 // 만약 reflection_id 가 recent인 경우에는 가장 최근 회고에서 feedback을 불러온다.
 const getCertainTypeFeedbackAll = async (req, res) => {

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -28,6 +28,30 @@ async function createFeedback(req, res, next) {
     }
 }
 
+// request data: team_id, reflection_id
+// query string: type
+// reponse data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
+// 특정 type을 만족하는 feedback을 불러온다.
+const getCertainTypeFeedbackAll = async (req, res) => {
+    try {
+        const { type } = req.query;
+        const { team_id, reflection_id } = req.params;
+
+        const feedbackData = await feedback.findAll({
+            where: {
+                type: type,
+                team_id: team_id,
+                reflection_id: reflection_id
+            }
+        })
+        return res.status(200).json({'success':true, 'message':'조회 성공','detail':feedbackData});
+    } catch (error) {
+        console.log(error);
+        return res.status(400).json({"success":false, "message":"조회 실패"})
+    }
+}
+
 module.exports = {
-    createFeedback
+    createFeedback,
+    getCertainTypeFeedbackAll
 };

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -33,12 +33,12 @@ async function createFeedback(req, res, next) {
 //team_id, reflection_id,reflection_name, 보내는 user_name
 // 특정 type을 만족하는 feedback을 불러온다.
 // 만약 reflection_id 가 recent인 경우에는 가장 최근 회고에서 feedback을 불러온다.
-const getCertainTypeFeedbackAll = async (req, res) => {
+const getCertainTypeFeedbackAll = async (req, res, next) => {
     try {
         const { type } = req.query;
         const { team_id, reflection_id } = req.params;
 
-        if (reflection_id == "recent") {
+        if (reflection_id == 'recent') {
             const teamData = await team.findByPk(team_id)
             const recentReflectionId = teamData.recent_reflection_id;
             const feedbackData = await feedback.findAll({
@@ -57,10 +57,10 @@ const getCertainTypeFeedbackAll = async (req, res) => {
                 ]
             })  
             return res.status(200).json({
-                'success':true,
-                'message':'최근 회고 피드백 조회 성공',
+                'success': true,
+                'message': '최근 회고 피드백 조회 성공',
                 'detail': {
-                    "feedback": [feedbackData]
+                    'feedback': [feedbackData]
                 }
             });         
         }
@@ -80,22 +80,23 @@ const getCertainTypeFeedbackAll = async (req, res) => {
             ]
         })
         return res.status(200).json({
-            'success':true,
-            'message':'피드백 정보 조회 성공',
+            'success': true,
+            'message': '피드백 정보 조회 성공',
             'detail': {
-                "feedback": [feedbackData]
+                'feedback': [feedbackData]
             }
         });
     } catch (error) {
         console.log(error);
         return res.status(400).json({
-            'success':false,
-            'message':'피드백 정보 조회 실패'
+            'success': false,
+            'message': '피드백 정보 조회 실패',
+            'detail': error.message
         })
     }
 }
 
 module.exports = {
     createFeedback,
-    getCertainTypeFeedbackAll,
+    getCertainTypeFeedbackAll
 };

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -46,7 +46,15 @@ const getCertainTypeFeedbackAll = async (req, res) => {
                     team_id: team_id,
                     reflection_id: recentReflectionId,
                     type: type
-                }
+                },
+                include: [
+                    {
+                        model: reflection, where: { id: recentReflectionId }
+                    },
+                    {
+                        model: user
+                    }
+                ]
             })  
             return res.status(200).json({'success':true, 'message':'최근 회고 피드백 조회 성공','detail':feedbackData});         
         }

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -28,23 +28,35 @@ async function createFeedback(req, res, next) {
     }
 }
 
-// request data: team_id, reflection_id
-// query string: type
-// reponse data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
+// request data: team_id, reflection_id, type
+// response data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
 // 특정 type을 만족하는 feedback을 불러온다.
+// 만약 reflection_id 가 recent인 경우에는 가장 최근 회고에서 feedback을 불러온다.
 const getCertainTypeFeedbackAll = async (req, res) => {
     try {
         const { type } = req.query;
         const { team_id, reflection_id } = req.params;
 
+        if (reflection_id == "recent") {
+            const teamData = await team.findByPk(team_id)
+            const recentReflectionId = teamData.recent_reflection_id;
+            const feedbackData = await feedback.findAll({
+                where: {
+                    team_id: team_id,
+                    reflection_id: recentReflectionId,
+                    type: type
+                }
+            })  
+            return res.status(200).json({'success':true, 'message':'최근 회고 피드백 조회 성공','detail':feedbackData});         
+        }
         const feedbackData = await feedback.findAll({
             where: {
-                type: type,
                 team_id: team_id,
-                reflection_id: reflection_id
+                reflection_id: reflection_id,
+                type: type
             }
         })
-        return res.status(200).json({'success':true, 'message':'조회 성공','detail':feedbackData});
+        return res.status(200).json({'success':true, 'message':'피드백 조회 성공','detail':feedbackData});
     } catch (error) {
         console.log(error);
         return res.status(400).json({"success":false, "message":"조회 실패"})
@@ -53,5 +65,5 @@ const getCertainTypeFeedbackAll = async (req, res) => {
 
 module.exports = {
     createFeedback,
-    getCertainTypeFeedbackAll
+    getCertainTypeFeedbackAll,
 };

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -2,12 +2,9 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
     createFeedback,
-    getCertainTypeFeedbackAll
+    getCertainTypeFeedbackAll,
 } = require('./feedbacks');
 
 router.post('/', createFeedback);
 router.get('/', getCertainTypeFeedbackAll);
-
-//* 특정 타입의 피드백 모두 가져오기
-//router.get("/:team_id/reflection/recent/feedbacks", getCertainTypeRecentFeedbackAll);
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -1,9 +1,13 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    createFeedback
+    createFeedback,
+    getCertainTypeFeedbackAll
 } = require('./feedbacks');
 
 router.post('/', createFeedback);
+router.get('/', getCertainTypeFeedbackAll);
 
+//* 특정 타입의 피드백 모두 가져오기
+//router.get("/:team_id/reflection/recent/feedbacks", getCertainTypeRecentFeedbackAll);
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -6,7 +6,7 @@ const {
 } = require('./reflections');
 
 router.get('/current', getReflectionInformation);
-router.get("/", getPastReflectionList);
+router.get('/', getPastReflectionList);
 
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -1,9 +1,12 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    getReflectionInformation
+    getReflectionInformation,
+    getPastReflectionList
 } = require('./reflections');
 
 router.get('/current', getReflectionInformation);
+router.get("/", getPastReflectionList);
+
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -12,7 +12,7 @@ async function getReflectionInformation(req, res, next) {
             attributes: ['current_reflection_id'],
             raw : true
         });
-        // 팀의 현재 회고의 reflection_name,date, status
+        // 팀의 현재 회고의 reflection_name, date, status
         const reflectionInformation = await reflection.findByPk(currentReflectionId.current_reflection_id);
         // 팀의 현재 회고에 속한 keywords
         const keywordsList = await feedback.findAll({
@@ -48,7 +48,7 @@ const getPastReflectionList = async (req, res) => {
 
     try {
         const reflectionData = await reflection.findAll({
-            where:{
+            where: {
                 team_id 
             }
         })

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -52,7 +52,11 @@ const getPastReflectionList = async (req, res) => {
                 team_id 
             }
         })
-        return res.status(200).json({"success":true,"message":"data 조회 성공","detail":reflectionData})
+        return res.status(200).json({
+            "success":true,
+            "message":"data 조회 성공",
+            "detail": [reflectionData]
+        })
     } catch (error) {
         return res.status(400).json()
     }

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -12,7 +12,7 @@ async function getReflectionInformation(req, res, next) {
             attributes: ['current_reflection_id'],
             raw : true
         });
-        // 팀의 현재 회고의 reflection_name, date, status
+        // 팀의 현재 회고의 reflection_name,date, status
         const reflectionInformation = await reflection.findByPk(currentReflectionId.current_reflection_id);
         // 팀의 현재 회고에 속한 keywords
         const keywordsList = await feedback.findAll({
@@ -39,6 +39,27 @@ async function getReflectionInformation(req, res, next) {
     }
 }
 
+
+//* 진행했던 회고목록 조회
+//* request data: team_id
+//* response data: id, reflection_name, date, state, team_id
+const getPastReflectionList = async (req, res) => {
+    const { team_id } = req.params;
+
+    try {
+        const reflectionData = await reflection.findAll({
+            where:{
+                team_id 
+            }
+        })
+        return res.status(200).json({"success":true,"message":"data 조회 성공","detail":reflectionData})
+    } catch (error) {
+        return res.status(400).json()
+    }
+
+}
+
 module.exports = {
-    getReflectionInformation
+    getReflectionInformation,
+    getPastReflectionList
 };

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -43,7 +43,7 @@ async function getReflectionInformation(req, res, next) {
 //* 진행했던 회고목록 조회
 //* request data: team_id
 //* response data: id, reflection_name, date, state, team_id
-const getPastReflectionList = async (req, res) => {
+const getPastReflectionList = async (req, res, next) => {
     const { team_id } = req.params;
 
     try {
@@ -51,17 +51,23 @@ const getPastReflectionList = async (req, res) => {
             where: {
                 team_id 
             }
-        })
+        });
         return res.status(200).json({
-            "success":true,
-            "message":"data 조회 성공",
-            "detail": [reflectionData]
-        })
+            "success": true,
+            "message": "data 조회 성공",
+            "detail": {
+                "reflection": [reflectionData]
+            }
+        });
     } catch (error) {
-        return res.status(400).json()
+        return res.status(400).json({
+            success: false,
+            message: "회고목록 조회 실패",
+            detail: error.message
+        });
     }
-
 }
+
 
 module.exports = {
     getReflectionInformation,


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 나의 회고에서, 현재 팀에서 진행했던 회고 목록 조회 API를 구현했습니다.
- 회고 모음집에서 유저가 받은 특정 타입의 피드백 정보를 조회하는 API를 구현했습니다.
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- [x] 현재 팀에서 진행했던 회고 목록 가져오기
- [x] 특정 회고에서 유저가 받은 특정 타입의 피드백 정보 모두 가져오기
- [x] 현재 팀의 최근 회고에서 유저가 받은 특정 타입의 피드백 정보 모두 가져오기

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
Postman을 이용하여, API Test

- 현재 팀에서 진행했던 회고 목록 가져오기
URI : GET /teams/1/reflections

- 특정 회고에서 유저가 받은 특정 타입의 피드백 정보 모두 가져오기
URI : GET /teams/1/reflections/1/feedbacks/?type=Stop

- 팀이 받은 최근 회고에서 특정 타입의 피드백 정보 모두 가져오기
URI : GET /teams/1/reflections/recent/feedbacks/?type=Stop

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/81692211/200174320-d3d5542b-b36e-4626-8b4e-cc92a8e0ba5c.png">

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/81692211/200174686-db0b2827-d187-4d82-bc6f-f74230ecc224.png">

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/81692211/200177316-5f65ce66-1e2d-4f76-8d6b-8402e634fe9d.png">



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #29 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
