### PR TITLE
[CHORE] response 포맷 수정 및 code convention 맞추기

### DIFF
--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -21,12 +21,13 @@ async function createFeedback(req, res, next) {
             team_id: req.params.team_id,
             reflection_id: req.params.reflection_id
         });
+
         res.status(201).json({
             success: true,
             message: '피드백 생성하기 성공',
             detail: createdFeedback
         });
-    } catch(error) {
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -21,10 +21,18 @@ async function createFeedback(req, res, next) {
             team_id: req.params.team_id,
             reflection_id: req.params.reflection_id
         });
-        res.status(201).json(createdFeedback);
+        res.status(201).json({
+            success: true,
+            message: '피드백 생성하기 성공',
+            detail: createdFeedback
+        });
     } catch(error) {
         // TODO: 에러 처리 수정
-        res.status(400).json(error);
+        res.status(400).json({
+            success: false,
+            message: '피드백 생성하기 실패',
+            detail: error.message
+        });
     }
 }
 

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    getReflectionInformation
+    getCurrentReflectionDetail
 } = require('./reflections');
 
-router.get('/current', getReflectionInformation);
+router.get('/current', getCurrentReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -10,7 +10,7 @@ async function getCurrentReflectionDetail(req, res, next) {
         // 팀의 현재 회고 id
         const currentReflectionId = await team.findByPk(req.params.team_id, {
             attributes: ['current_reflection_id'],
-            raw : true
+            raw: true
         });
 
         // 팀의 현재 회고의 reflection_name, date, status
@@ -28,11 +28,11 @@ async function getCurrentReflectionDetail(req, res, next) {
         
         // 위 데이터 중 필요한 부분을 합친 response 데이터 만들기
         const reflectionFinalInformation = {
-            current_reflection_id : currentReflectionId.current_reflection_id,
-            reflection_name : reflectionInformation.reflection_name,
-            reflection_date : reflectionInformation.date,
-            reflection_status : reflectionInformation.state,
-            reflection_keywords : keywordsList.map((data) => data.keyword)
+            current_reflection_id: currentReflectionId.current_reflection_id,
+            reflection_name: reflectionInformation.reflection_name,
+            reflection_date: reflectionInformation.date,
+            reflection_status: reflectionInformation.state,
+            reflection_keywords: keywordsList.map((data) => data.keyword)
         }
 
         res.status(200).json({
@@ -41,7 +41,7 @@ async function getCurrentReflectionDetail(req, res, next) {
             detail: reflectionFinalInformation
         });
 
-    } catch(error) {
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -3,7 +3,7 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // request data : user_id, team_id
 // response data : current_reflection_id, reflection_name, date, status, 회고에 속한 keywords 목록
 // 팀에서 진행하는 현재의 회고 정보 가져오기
-async function getReflectionInformation(req, res, next) {
+async function getCurrentReflectionDetail(req, res, next) {
     console.log("현재 회고 정보 가져오기");
 
     try {
@@ -12,8 +12,10 @@ async function getReflectionInformation(req, res, next) {
             attributes: ['current_reflection_id'],
             raw : true
         });
+
         // 팀의 현재 회고의 reflection_name, date, status
         const reflectionInformation = await reflection.findByPk(currentReflectionId.current_reflection_id);
+        
         // 팀의 현재 회고에 속한 keywords
         const keywordsList = await feedback.findAll({
             attributes: ['keyword'],
@@ -23,6 +25,7 @@ async function getReflectionInformation(req, res, next) {
             raw : true
         });
         console.log(keywordsList);
+        
         // 위 데이터 중 필요한 부분을 합친 response 데이터 만들기
         const reflectionFinalInformation = {
             current_reflection_id : currentReflectionId.current_reflection_id,
@@ -31,14 +34,23 @@ async function getReflectionInformation(req, res, next) {
             reflection_status : reflectionInformation.state,
             reflection_keywords : keywordsList.map((data) => data.keyword)
         }
-        res.status(200).json(reflectionFinalInformation);
+
+        res.status(200).json({
+            success: true,
+            message: '현재 회고 정보 가져오기 성공',
+            detail: reflectionFinalInformation
+        });
 
     } catch(error) {
         // TODO: 에러 처리 수정
-        res.status(400).send(error);
+        res.status(400).json({
+            success: false,
+            message: '현재 회고 정보 가져오기 실패',
+            detail: error.message
+        });
     }
 }
 
 module.exports = {
-    getReflectionInformation
+    getCurrentReflectionDetail
 };

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -2,12 +2,12 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
     createTeam,
-    getTeamInformation,
+    getCertainTeamInformation,
     getTeamMembers
 } = require('./teams');
 
 router.post('/', createTeam);
-router.get('/:team_id', getTeamInformation);
+router.get('/:team_id', getCertainTeamInformation);
 router.get('/:team_id/members', getTeamMembers);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -2,12 +2,12 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
     createTeam,
-    getCertainTeamInformation,
+    getCertainTeamDetail,
     getTeamMembers
 } = require('./teams');
 
 router.post('/', createTeam);
-router.get('/:team_id', getCertainTeamInformation);
+router.get('/:team_id', getCertainTeamDetail);
 router.get('/:team_id/members', getTeamMembers);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -4,9 +4,9 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // reference : https://www.programiz.com/javascript/examples/generate-random-strings
 function generateCode() {
     let generatedCode = '';
-    const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZ";
+    const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZ';
     const codeLen = 6;
-    for (let i=0; i<codeLen; i++) {
+    for (let i = 0; i < codeLen; i++) {
         generatedCode += chars.charAt(Math.floor(Math.random() * chars.length));
     }
     return generatedCode;
@@ -15,7 +15,7 @@ function generateCode() {
 // 팀 invitation_code 중복 여부 체크
 function checkDuplicateCode(createdTeamCode) {
     const duplicateCode = team.findOne({
-        where : {
+        where: {
             invitation_code: createdTeamCode
         }
     });
@@ -39,7 +39,7 @@ async function createTeam(req, res, next) {
         let createdTeamCode;
         do {
             createdTeamCode = generateCode();
-        } while (checkDuplicateCode(createdTeamCode))
+        } while (checkDuplicateCode(createdTeamCode));
 
         // 팀 생성
         const createdTeam = await team.create({
@@ -56,7 +56,7 @@ async function createTeam(req, res, next) {
         const updatedTeam = await team.update({
             current_reflection_id: createdReflection.id
         }, {
-            where : {
+            where: {
                 id: createdTeam.id
             }
         });
@@ -73,6 +73,7 @@ async function createTeam(req, res, next) {
             message: '팀 생성 완료, 유저를 해당 팀의 리더로 설정',
             detail: createdTeam
         });
+
     } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
@@ -94,19 +95,19 @@ async function getCertainTeamDetail(req, res, next) {
         const teamBasicInformation = await team.findByPk(req.params.team_id);
         // 유저가 팀의 리더인지 확인
         const teamLeader = await userteam.findOne({
-            where : {
-                user_id : req.header('user_id'),
-                team_id : req.params.team_id
+            where: {
+                user_id: req.header('user_id'),
+                team_id: req.params.team_id
             },
-            raw : true
+            raw: true
         });
 
         // 위 데이터 중 필요한 부분을 합친 response 데이터 만들기
         const teamFinalInformation = {
-            team_id : req.params.team_id,
-            team_name : teamBasicInformation.team_name,
-            invitation_code : teamBasicInformation.invitation_code,
-            admin : teamLeader.admin
+            team_id: req.params.team_id,
+            team_name: teamBasicInformation.team_name,
+            invitation_code: teamBasicInformation.invitation_code,
+            admin: teamLeader.admin
         }
 
         res.status(200).json({
@@ -115,7 +116,7 @@ async function getCertainTeamDetail(req, res, next) {
             detail: teamFinalInformation
         });
 
-    } catch(error) {
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,
@@ -135,22 +136,22 @@ async function getTeamMembers(req, res, next) {
         // TODO : 불필요한 필드 제거 (user.username)
         // 멤버 목록 가져오기
         const teamMemberList = await userteam.findAll({
-            attributes : ['user_id', 'user.username'],
-            where : {
+            attributes: ['user_id', 'user.username'],
+            where: {
                 team_id: req.params.team_id
             },
-            include : { 
+            include: { 
                 model: user,
                 attributes: ['username'],
                 required: true 
             },
-            raw : true
+            raw: true
         });
         if (teamMemberList.length === 0) { throw Error('팀이 존재하지 않음'); }
 
         teamMemberList.map((data) => (delete data['user.username']));
         const teamMemberInformation = {
-            members : teamMemberList
+            members: teamMemberList
         }
 
         res.status(200).json({
@@ -159,7 +160,7 @@ async function getTeamMembers(req, res, next) {
             detail: teamMemberInformation
         });
 
-    } catch(error) {
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -86,7 +86,7 @@ async function createTeam(req, res, next) {
 // request data : user_id, team_id
 // response data : team_id, team_name, invitation_code, admin
 // 팀의 정보 가져오기
-async function getCertainTeamInformation(req, res, next) {
+async function getCertainTeamDetail(req, res, next) {
     console.log("팀의 정보 가져오기");
 
     try {
@@ -171,6 +171,6 @@ async function getTeamMembers(req, res, next) {
 
 module.exports = {
     createTeam,
-    getCertainTeamInformation,
+    getCertainTeamDetail,
     getTeamMembers
 };

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -16,7 +16,8 @@ async function userLogin(req, res, next) {
             message: '유저 로그인 성공',
             datail: createdUser
         });
-    } catch(error) {
+
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,
@@ -36,13 +37,13 @@ async function userJoinTeam(req, res, next) {
 
     try {
         const requestTeam = await team.findOne({
-            where : {
+            where: {
                 invitation_code: userTeamContent.invitation_code
             },
-            raw : true
+            raw: true
         });
         // 초대 코드가 일치하는 팀이 없을 경우
-        if (requestTeam == null) {
+        if (requestTeam === null) {
             console.log("team not found");
             // TODO: 초대 코드가 잘못 됐을 경우 에러 처리 추가
         }
@@ -57,7 +58,7 @@ async function userJoinTeam(req, res, next) {
             detail: createdUserteam
         });
         // TODO: response 과정 에러 처리 추가
-    } catch(error) {
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,
@@ -82,7 +83,7 @@ async function userLeaveTeam(req, res, next) {
         });
         // TODO: 삭제가 제대로 수행 안됐을 경우 에러 처리 추가
         // TODO: 삭제할 데이터가 없을 경우 에러 처리 추가
-        if (deletedUserTeam == 1) { // 삭제할 데이터 있음
+        if (deletedUserTeam === 1) { // 삭제할 데이터 있음
             res.status(200).json({
                 success: true,
                 message: '유저 팀 탈퇴 성공'
@@ -94,7 +95,7 @@ async function userLeaveTeam(req, res, next) {
                 detail: '유저와 팀 정보가 잘못됨'
             });
         }
-    } catch(error) {
+    } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -11,10 +11,18 @@ async function userLogin(req, res, next) {
 
     try {
         const createdUser = await user.create(userContent);
-        res.status(201).send(createdUser);
+        res.status(201).json({
+            success: true,
+            message: '유저 로그인 성공',
+            datail: createdUser
+        });
     } catch(error) {
         // TODO: 에러 처리 수정
-        res.status(400).send(error);
+        res.status(400).json({
+            success: false,
+            message: '유저 로그인 실패',
+            detail: error.message
+        });
     }
 }
 
@@ -43,11 +51,19 @@ async function userJoinTeam(req, res, next) {
             user_id: req.header('user_id'),
             team_id: requestTeam.id
         });
-        res.status(201).send(createdUserteam);
+        res.status(201).json({
+            success: true,
+            message: '유저 팀 합류 성공',
+            detail: createdUserteam
+        });
         // TODO: response 과정 에러 처리 추가
     } catch(error) {
         // TODO: 에러 처리 수정
-        res.status(400).send(error);
+        res.status(400).json({
+            success: false,
+            message: '유저 팀 합류 실패',
+            detail: error.message
+        });
     }
 }
 
@@ -67,13 +83,24 @@ async function userLeaveTeam(req, res, next) {
         // TODO: 삭제가 제대로 수행 안됐을 경우 에러 처리 추가
         // TODO: 삭제할 데이터가 없을 경우 에러 처리 추가
         if (deletedUserTeam == 1) { // 삭제할 데이터 있음
-            res.status(200).send("success");
+            res.status(200).json({
+                success: true,
+                message: '유저 팀 탈퇴 성공'
+            });
         } else { // 삭제할 데이터 없음
-            res.status(202).send("no such data");
+            res.status(400).json({
+                success: false,
+                message: '유저 팀 탈퇴 실패',
+                detail: '유저와 팀 정보가 잘못됨'
+            });
         }
     } catch(error) {
         // TODO: 에러 처리 수정
-        res.status(400).send(error);
+        res.status(400).json({
+            success: false,
+            message: '유저 팀 탈퇴 실패',
+            detail: error.message
+        });
     }
 }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
response 포맷을 다음과 같이 통일하기로 결정했습니다.
<img width="700" alt="image" src="https://user-images.githubusercontent.com/67336936/200227666-f03d117b-bc21-499d-a259-1f150a1316b7.png">
javascript code convention은 다음 규칙을 따르기로 결정했습니다.
https://spice-gym-2c0.notion.site/Javascript-Convention-5babfec9dfc245a5b5efda83c1d99e88

따라서 기존에 작성한 코드를 규칙에 맞게 전체적으로 수정하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- response format 변경
  ```javascript
    res.status(201).json({
        success: true,
        message: '유저 로그인 성공',
        datail: createdUser
    });
    res.status(400).json({
        success: false,
        message: '유저 로그인 실패',
        detail: error.message
    });
   ```
- convention에 맞게 공백 추가 및 제거
- 모듈 이름 보다 명확하게 변경
  getTeamInformation -> getCertainTeamDetail
  getReflectionInformation -> getCurrentReflectionDetail

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
19번 브랜치 pull 받으셔서 실행시킨 후, postman에서 userLogin, userJoinTeam, userLeaveTeam, createTeam, getCertainTeamDetail, getTeamMembers, getCurrentReflectionDetail, createFeedback request 보내보시면 정한 response 형식에 맞춰 응답 오는 것 확인하실 수 있습니다!

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
ex)
<img width="467" alt="image" src="https://user-images.githubusercontent.com/67336936/200228283-bc83fc50-4a4e-4756-9fed-b7d44c623f27.png">
<img width="691" alt="image" src="https://user-images.githubusercontent.com/67336936/200228405-cefbfdf5-24c3-4fc6-9013-ca87ee155962.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
제가 놓친 부분이 있다면 뭐든 말씀해주셔도 됩니다😀
이 PR 머지되면 해당 API 명세 업데이트 하겠습니다~!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #19 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
