### PR TITLE
[FEAT] Home View api 구현 - 회고 상세 정보 추가

### DIFF
--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    getCurrentReflectionDetail
+    getCurrentReflectionDetail,
+    updateReflectionDetail
 } = require('./reflections');
 
 router.get('/current', getCurrentReflectionDetail);
+router.patch('/:reflection_id', updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -53,14 +53,14 @@ async function getCurrentReflectionDetail(req, res, next) {
 // request data : user_id, team_id, reflection_id
 // response data : reflection_id, reflection_name, date, status
 // 팀의 리더가 팀의 현재 회고에 디테일 정보(이름, 일시)를 추가한다.
-async function updateReflectionDetail(req, res, next) {
-    console.log('회고 정보 추가하기');
-    const { team_id, reflection_id } = req.params;
-    const { reflection_name, reflection_date } = req.body;
+const updateReflectionDetail = async (req, res, next) => {
     // TODO: 유저가 현재 팀의 리더인지 검증(미들웨어)
     // TODO: 회고의 status가 회고 정보를 추가할 수 있는 상태인지 검증(미들웨어)
-
     try {
+        console.log('회고 정보 추가하기');
+        const { reflection_id } = req.params;
+        const { reflection_name, reflection_date } = req.body;
+
         // 피드백 상세 정보 추가
         const updateReflectionSuccess = await reflection.update({
             reflection_name: reflection_name,

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -51,6 +51,49 @@ async function getCurrentReflectionDetail(req, res, next) {
     }
 }
 
+// request data : user_id, team_id, reflection_id
+// response data : reflection_id, reflection_name, date, status
+// 팀의 리더가 팀의 현재 회고에 디테일 정보(이름, 일시)를 추가한다.
+async function updateReflectionDetail(req, res, next) {
+    console.log('회고 정보 추가하기');
+    const { team_id, reflection_id } = req.params;
+    const { reflection_name, reflection_date } = req.body;
+    // TODO: 유저가 현재 팀의 리더인지 검증(미들웨어)
+    // TODO: 회고의 status가 회고 정보를 추가할 수 있는 상태인지 검증(미들웨어)
+
+    try {
+        // 피드백 상세 정보 추가
+        const updateReflectionSuccess = await reflection.update({
+            reflection_name: reflection_name,
+            date: reflection_date,
+            state: 'Before'
+        }, {
+            where: {
+                id: reflection_id,
+            },
+        });
+
+        if (updateReflectionSuccess[0] === 0) throw Error('일치하는 회고 정보를 찾지 못함');
+
+        const reflectionDetail = await reflection.findByPk(reflection_id);
+
+        res.status(200).json({
+            success: true,
+            message: '회고 디테일 정보 추가 성공',
+            detail: reflectionDetail
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '회고 디테일 정보 추가 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
-    getCurrentReflectionDetail
+    getCurrentReflectionDetail,
+    updateReflectionDetail
 };


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
<img width="900" alt="image" src="https://user-images.githubusercontent.com/67336936/200643947-0f04a043-2584-4244-b4ca-e9bd560c661c.png">
홈 뷰에서 아직 회고 정보가 등록되지 않은 상태일 때 리더가 회고 상세 정보를 추가하는 api를 구현했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회고 상세 정보 추가 api 구현

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
postman에서 updateReflectionDetail 호출하시면 됩니다.
- PATCH api/v1/teams/{team_id}/reflections/{reflection_id}
- request body
  ```javascript
   {
    "reflection_name" : "서버 테스트 회고",
    "reflection_date" : "2022-11-20"
   }
  ```
## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/200644586-68998631-3110-440e-8195-bc9073af1144.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/200644425-4dd483f7-3275-4d78-8c06-8ce6d8a02e05.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- sequelize에서 update 성공 후 해당 레코드를 return하는 방법을 찾지 못해서, update 성공 후에는 pk로 해당 레코드를 다시 찾는 과정을 수행했습니다. 좋은 방법이 있다면 알려주세요!
- 팀의 상태를 검증하는 부분, 유저가 팀의 리더인지 검증하는 부분은 추후 미들웨어 구현 후 추가할 예정입니다.
- 일부분 (회고 이름, 날짜)만 변경하기 때문에 PUT이 아닌 PATCH를 통해 request를 보내도록 구현했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #32 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
