### PR TITLE
[FEAT] middleware 구현 - 유저의 팀 검증, 리더 검증

### DIFF
--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -17,10 +17,17 @@ sequelize.sync({ force: false })
     console.error(err);
 });
 
+// middleware module import
+const {
+  userTeamCheck
+} = require('./middlewares/auth');
 
 app.get('/', (req, res) => {
   res.send('Hello World! This is KeyGo server')
 })
+
+// middleware 적용
+app.use('/teams/:team_id', userTeamCheck);
 
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
 app.use('/users', require('./routes/users/index'));

--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -17,17 +17,9 @@ sequelize.sync({ force: false })
     console.error(err);
 });
 
-// middleware module import
-const {
-  userTeamCheck
-} = require('./middlewares/auth');
-
 app.get('/', (req, res) => {
   res.send('Hello World! This is KeyGo server')
-})
-
-// middleware 적용
-app.use('/teams/:team_id', userTeamCheck);
+});
 
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
 app.use('/users', require('./routes/users/index'));

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -25,6 +25,33 @@ const userTeamCheck = async (req, res, next) => {
     }
 }
 
+const userAdminCheck = async (req, res, next) => {
+    try {
+        console.log('유저의 현재 팀 리더 검증');
+        const user_id = req.header('user_id');
+        const { team_id, ...other } = req.params;
+
+        // 요청을 보낸 유저가 요청 대상 팀(team_id)의 리더인지 확인하기
+        const isLeader = await userteam.findOne({
+            where: {
+                user_id: user_id,
+                team_id: team_id
+            },
+            raw: true
+        });
+        if (isLeader.admin === 0) throw Error('유저가 요청 대상 팀의 리더가 아님');
+        next();
+
+    } catch (error) {
+        res.status(400).json({
+            success: false,
+            message: '요청 권한 없음',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
-    userTeamCheck
+    userTeamCheck,
+    userAdminCheck
 }

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -1,0 +1,30 @@
+const {user, team, userteam, reflection, feedback} = require('../models');
+
+const userTeamCheck = async (req, res, next) => {
+    try {
+        console.log('유저의 팀 검증');
+        const user_id = req.header('user_id');
+        const { team_id, ...other } = req.params;
+
+        // 요청을 보낸 유저가 요청 대상 팀(team_id)에 속해있는지 확인하기
+        const findUserTeam = await userteam.findOne({
+            where: {
+                user_id: user_id,
+                team_id: team_id
+            }
+        });
+        if (findUserTeam === null) throw Error('유저가 요청 대상 팀에 속해있지 않음');
+        next();
+
+    } catch (error) {
+        res.status(400).json({
+            success: false,
+            message: '요청 권한 없음',
+            detail: error.message
+        });
+    }
+}
+
+module.exports = {
+    userTeamCheck
+}

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -4,7 +4,11 @@ const {
     createFeedback,
     getCertainTypeFeedbackAll,
 } = require('./feedbacks');
+const {
+    userTeamCheck,
+    userAdminCheck
+} = require('../../middlewares/auth');
 
-router.post('/', createFeedback);
-router.get('/', getCertainTypeFeedbackAll);
+router.post('/', [userTeamCheck], createFeedback);
+router.get('/', [userTeamCheck], getCertainTypeFeedbackAll);
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -5,9 +5,12 @@ const {
     updateReflectionDetail,
     getPastReflectionList
 } = require('./reflections');
+const {
+    userAdminCheck
+} = require('../../middlewares/auth');
 
 router.get('/', getPastReflectionList);
 router.get('/current', getCurrentReflectionDetail);
-router.patch('/:reflection_id', updateReflectionDetail);
+router.patch('/:reflection_id', [userAdminCheck], updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -6,11 +6,12 @@ const {
     getPastReflectionList
 } = require('./reflections');
 const {
+    userTeamCheck,
     userAdminCheck
 } = require('../../middlewares/auth');
 
-router.get('/', getPastReflectionList);
-router.get('/current', getCurrentReflectionDetail);
-router.patch('/:reflection_id', [userAdminCheck], updateReflectionDetail);
+router.get('/', [userTeamCheck], getPastReflectionList);
+router.get('/current', [userTeamCheck], getCurrentReflectionDetail);
+router.patch('/:reflection_id', [userTeamCheck, userAdminCheck], updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -5,12 +5,6 @@ const {
     getCertainTeamDetail,
     getTeamMembers
 } = require('./teams');
-// const {
-//     userTeamCheck
-// } = require('../../middlewares/auth');
-
-// // middleware
-// router.use('/:team_id', userTeamCheck);
 
 // function
 router.post('/', createTeam);

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -5,10 +5,13 @@ const {
     getCertainTeamDetail,
     getTeamMembers
 } = require('./teams');
+const {
+    userTeamCheck,
+    userAdminCheck
+} = require('../../middlewares/auth');
 
-// function
 router.post('/', createTeam);
-router.get('/:team_id', getCertainTeamDetail);
-router.get('/:team_id/members', getTeamMembers);
+router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);
+router.get('/:team_id/members', [userTeamCheck], getTeamMembers);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -5,7 +5,14 @@ const {
     getCertainTeamDetail,
     getTeamMembers
 } = require('./teams');
+const {
+    userTeamCheck
+} = require('../../middlewares/auth');
 
+// middleware
+router.use('/:team_id', userTeamCheck);
+
+// functions
 router.post('/', createTeam);
 router.get('/:team_id', getCertainTeamDetail);
 router.get('/:team_id/members', getTeamMembers);

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -5,14 +5,14 @@ const {
     getCertainTeamDetail,
     getTeamMembers
 } = require('./teams');
-const {
-    userTeamCheck
-} = require('../../middlewares/auth');
+// const {
+//     userTeamCheck
+// } = require('../../middlewares/auth');
 
-// middleware
-router.use('/:team_id', userTeamCheck);
+// // middleware
+// router.use('/:team_id', userTeamCheck);
 
-// functions
+// function
 router.post('/', createTeam);
 router.get('/:team_id', getCertainTeamDetail);
 router.get('/:team_id/members', getTeamMembers);


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
특정 팀 혹은 팀에 속한 회고/피드백/멤버 정보의 조회, 추가, 수정, 삭제를 요청할 때, 요청을 보낸 유저가 해당 팀의 속한 유저인지 검증하는 과정이 필요합니다.
팀의 회고 정보를 등록하거나 진행 중인 회고를 종료하는 과정에서, 요청을 보낸 유저가 해당 팀의 리더인지 검증하는 과정이 필요합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
미들웨어는 middlewares 폴더 내에 구현하였으며, 유저의 팀 검증과 리더 검증 모두 요청 권한에 관한 과정이기 때문에 auth 파일의 내부에 구현하였습니다.

- **유저가 요청을 보낸 팀에 속한 멤버인지 검증하는 미들웨어를 구현, 적용하였습니다.**
  `/team/{team_id}/` 로 시작하는 end point는 모두 요청을 보낸 유저가 해당 팀에 속한 멤버인지 검증하는 과정을 거쳐야 합니다.
   따라서 app.js 파일에서 아래 코드를 추가하여, `/team/{team_id}` 로 시작하는 모든 요청이 유저의 팀 검증 미들웨어를 거치도록 구현하였습니다.
   ```javascript
   // middleware 적용
   app.use('/teams/:team_id', userTeamCheck);
   ```
- **유저가 요청을 보낸 팀의 리더인지 검증하는 미들웨어를 구현, 적용하였습니다.**
   유저가 현재 팀의 리더인지 검증하는 과정은 회고 정보 추가와 회고 종료 요청에서만 수행됩니다. 유저의 팀 검증 미들웨어와 달리, 공통적인 end point 형식을 가지는 모든 요청에서 유저의 리더 검증이 필요한 것이 아닙니다. 따라서 해당 미들웨어를 필요로 하는 request를 수행하는 로직에 유저의 리더 검증 함수를 추가하였습니다.
   ```javascript
   router.patch('/:reflection_id', [userAdminCheck], updateReflectionDetail);
   ```
   위와 같이 핸들러에 [함수, 함수] 형식을 추가하면 배열 안의 함수를 순차적으로 수행하게 됩니다. 함수 내에 `next()` 를 통해 다음 함수로 넘어갈 수 있으며, 수행 도중 에러가 발생하면 다음 함수로 넘어가지 않고 요청 수행이 중단됩니다.
   

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
**request header에 user_id를 지정하여 요청을 보내야 합니다.**
- `/teams/{team_id}/`로 시작하는 request를 보낼 때 유저가 현재 팀에 속해있지 않을 경우 에러가 발생합니다.
- 회고 정보 추가하기 request를 보낼 때 유저가 현재 팀의 리더가 아닐 경우 에러가 발생합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
유저의 팀 검증 실패
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/201412928-717c7a32-40d2-44ed-86f6-01860525bcaf.png">
유저의 리더 검증 실패
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/201413172-5c6fddc9-d6a7-40d6-9d04-3548ce3d4dc0.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
1. 1번 방법
   ```javascript
   // app.js 파일
   app.use('/teams/:team_id', userTeamCheck);
   ```
2. 2번 방법
   ```javascript
   // routes/teams/index.js 파일
   router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);
   ```
1번 방법과 2번 방법 모두 수행 과정은 동일합니다.
하지만 공식문서에 따르면 1번 방법으로 사용하는 것을 미들웨어를 사용한다고 말하는 것 같고, 2번 방법의 경우는 이벤트 핸들러에 여러 개의 콜백 함수를 지정한다~는 식으로 표현되고 있는 것 같습니다.
그래도 의미 상 요청 중간에 거쳐가는 함수는 맞기 때문에 어떤 방식으로 구현되든 미들웨어 라고 통칭하려고 합니다!

1번과 2번의 구체적인 차이는 잘 모르겠지만, 많은 request에서 필요로 하고, request가 공통적인 end point 규칙을 가지는 미들웨어는 1번 방식으로 구현하는 것이 좋을 것 같습니다. 2번 방식으로 구현하게 되면 미들웨어가 필요한 모든 request에서 일일이 함수를 추가해줘야 하기 때문입니다.

1번과 2번이 구체적으로 어떻게 다른지는 좀 더 공부가 필요할 것 같습니다🙂

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
