### PR TITLE
[FEAT] MyBox View api 구현 - 특정 멤버에게 작성한 피드백 가져오기

### DIFF
--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -4,7 +4,7 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // response data : feedback information(type, keyword, content, from_id, to_id, is_favorite, start_content)
 // 회고에 새로운 피드백을 등록한다 
 async function createFeedback(req, res, next) {
-    console.log("피드백 생성하기");
+    // console.log("피드백 생성하기");
     const feedbackContent = req.body;
     // TODO: 데이터 형식 맞지 않는 경우 에러 처리 추가
     // TODO: 받는 사람이 현재 팀에 없는 경우 에러 처리
@@ -109,7 +109,7 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
     피드백 type 별 feedback detail(keyword, content, start_content) */
 // 팀의 현재 회고에 담긴 피드백 중 유저가 특정 멤버에게 작성한 피드백 정보 가져오기
 const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
-    console.log('특정 멤버에게 작성한 피드백 리스트 가져오기');
+    // console.log('특정 멤버에게 작성한 피드백 리스트 가져오기');
 
     try {
         const { reflection_id, team_id } = req.params;
@@ -150,7 +150,7 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
         }
         feedbacksToCertainMember.map((data) => {
             const { type, ...contents } = data;
-            console.log(contents);
+            // console.log(contents);
             feedbacksToCertainMemberGroupByType[type].push(contents);
         });
 

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -1,5 +1,4 @@
 const {user, team, userteam, reflection, feedback} = require('../../models');
-var sequelize = require('sequelize');
 
 // request data : user_id, team_id, reflection_id, feedback information(type, keyword, content, to_id, start_content)
 // response data : feedback information(type, keyword, content, from_id, to_id, is_favorite, start_content)

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -1,4 +1,5 @@
 const {user, team, userteam, reflection, feedback} = require('../../models');
+var sequelize = require('sequelize');
 
 // request data : user_id, team_id, reflection_id, feedback information(type, keyword, content, to_id, start_content)
 // response data : feedback information(type, keyword, content, from_id, to_id, is_favorite, start_content)
@@ -105,7 +106,64 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
     }
 }
 
+// request data :  user_id, team_id, 피드백을 받는 유저의 user_id
+/* response data : user_id, team_id, reflection_id, 피드백을 받는 유저의 user_id, username, 
+    피드백 type 별 feedback detail(keyword, content, start_content) */
+// 팀의 현재 회고에 담긴 피드백 중 유저가 특정 멤버에게 작성한 피드백 정보 가져오기
+const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
+    console.log('특정 멤버에게 작성한 피드백 리스트 가져오기');
+
+    try {
+        const { reflection_id, team_id } = req.params;
+        const { members } = req.query;
+        const user_id = req.header('user_id');
+
+        // 팀이 진행 중인 현재 회고 id 가져오기
+        if (reflection_id !== 'current') throw Error('잘못된 요청 URI');
+        const currentReflectionId = await team.findByPk(team_id, {
+            attributes: ['current_reflection_id'],
+            raw: true
+        });
+        console.log(currentReflectionId);
+
+        // 현재 회고의 피드백 중 유저가 특정 멤버에게 작성한 피드백 정보 가져오기
+        const feedbacksToCertainMember = await feedback.findAll({
+            attributes: ['to_id', 'user.username', 'type', 'content', 'start_content'],
+            where: {
+                reflection_id: currentReflectionId.current_reflection_id,
+                from_id: user_id,
+                to_id: members
+            },
+            include: {
+                model: user,
+                attributes: [['id', 'to_id'], 'username']
+            },
+            order: ['type'],
+            raw: true
+        });
+        console.log(feedbacksToCertainMember);
+        
+        // 유저가 탈퇴했을 경우 username은 null로
+        res.status(200).json({
+            success: true,
+            message: '특정 멤버에게 작성한 피드백 목록 가져오기 성공',
+            detail: feedbacksToCertainMember
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '특정 멤버에게 작성한 피드백 목록 가져오기 실패',
+            detail: error.message
+        });
+    }
+
+
+}
+
 module.exports = {
     createFeedback,
-    getCertainTypeFeedbackAll
+    getCertainTypeFeedbackAll,
+    getFromMeToCertainMemberFeedbackAll
 };

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -142,7 +142,8 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
         
         // type 기준으로 그룹화하여 묶기
         const feedbacksToCertainMemberGroupByType = {
-            'reflection_id': currentReflectionId.currentReflectionId,
+            'team_id': team_id,
+            'reflection_id': currentReflectionId.current_reflection_id,
             'from_id': user_id,
             'to_id': members,
             'to_username': membersDetail.username,

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -3,8 +3,10 @@ const router = new express.Router({ mergeParams: true });
 const {
     createFeedback,
     getCertainTypeFeedbackAll,
+    getFromMeToCertainMemberFeedbackAll
 } = require('./feedbacks');
 
 router.post('/', createFeedback);
 router.get('/', getCertainTypeFeedbackAll);
+router.get('/from_me', getFromMeToCertainMemberFeedbackAll);
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -16,6 +16,6 @@ router.post('/', [userTeamCheck], createFeedback);
 router.get('/', [userTeamCheck], getCertainTypeFeedbackAll);
 router.put('/:feedback_id', updateFeedback);
 router.delete("/:feedback_id", deleteFeedback);
-router.get('/from_me', getFromMeToCertainMemberFeedbackAll);
+router.get('/from-me', getFromMeToCertainMemberFeedbackAll);
 
 module.exports = router;


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
MyBox 탭을 눌렀을 때, 팀에서 진행 중인 현재 회고의 피드백 중 요청을 보낸 유저가 특정 멤버에게 작성한 피드백 목록을 가져옵니다.
Continue, Stop 에 따라 구분해서 보여주기 때문에, 피드백 type 별로 피드백 디테일 정보를 담아 response합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
1. 팀에서 진행 중인 현재 회고의 id를 가져옵니다.
   요청이 `reflections/current/...` 형식으로 들어오지 않는 경우 에러를 발생시킵니다.
2. 받는 유저의 정보를 가져옵니다.
   만약 유저 테이블에 받는 유저의 정보가 없다면 에러를 발생시킵니다.
3. 피드백 테이블에서 현재 회고의 id, 보내는 유저의 id, 받는 유저의 id가 일치하는 피드백을 가져옵니다.
4. 피드백의 type(Continue, Stop) 별로 피드백을 분류한 후 response 합니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
27번 브랜치로 오신 후 postman의 getFromMeToCertainMemberFeedbackAll 요청을 보내시면 됩니다.
header에 반드시 'user_id' 값이 포함되어있어야 합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- 성공했을 경우
<img width="630" alt="image" src="https://user-images.githubusercontent.com/67336936/201517258-630ba7c8-8c91-4355-8bd2-f28a52e99e14.png">

- 실패했을 경우
<img width="622" alt="image" src="https://user-images.githubusercontent.com/67336936/201517278-24e87fa0-7e86-4b95-ba2f-4cf78dc132e4.png">



## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #27 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
