### PR TITLE
[FEAT] InProgress View - 피드백 정보 분류, 회고 종료 API 구현 

### DIFF
--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -182,33 +182,47 @@ const deleteFeedback = async (req, res, next) => {
 //* reponse data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
 //* 회고의 특정 유저와 유저가 속한 팀의 피드백을 분류하여 조회하는 API
 const getTeamAndUserFeedback = async (req, res) => {
+    const user_id = req.header('user_id');
 
     try {
         const member_id = req.query.members;
         const { team_id, reflection_id } = req.params
 
-    const userFeedbackData = await feedback.findAll({
-        where: {
-            team_id: team_id,
-            reflection_id: reflection_id,
-            from_id: member_id
-        }
+        const userFeedbackData = await feedback.findAll({
+            where: {
+                team_id: team_id,
+                reflection_id: reflection_id,
+                to_id: member_id,
+                from_id: user_id
+            },
+            include: {
+                model: user,
+                attributes: ['username'],
+                required: true
+            }
     });
 
     const teamFeedbackData = await feedback.findAll({
         where: {
             team_id: team_id,
             reflection_id: reflection_id,
-            from_id: {
+            to_id: {
                 [Op.ne]: member_id
-            }
+            },
+            from_id: user_id
         }
     })
-    console.log(teamFeedbackData);
+
+    if (user_id !== member_id) { 
+        const category = "others";
+    }
+    const category = "self";
+
     return res.status(200).json({
         success: true,
         message: "피드백 조회 성공",
         data: {
+            category: category,
             user_feedback: userFeedbackData,
             team_feedback: teamFeedbackData 
         }

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -1,4 +1,4 @@
-const {user, team, userteam, reflection, feedback, sequelize} = require('../../models');
+const {user, team, reflection, feedback } = require('../../models');
 const { Op } = require("sequelize");
 
 // request data : user_id, team_id, reflection_id, feedback information(type, keyword, content, to_id, start_content)

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -1,4 +1,3 @@
-const { where } = require('sequelize');
 const {user, team, userteam, reflection, feedback} = require('../../models');
 
 // request data : user_id, team_id, reflection_id, feedback information(type, keyword, content, to_id, start_content)

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -213,11 +213,12 @@ const getTeamAndUserFeedback = async (req, res) => {
         }
     })
 
+    let category = "self";
+    
     if (user_id !== member_id) { 
-        const category = "others";
+       category = "others";
     }
-    const category = "self";
-
+    
     return res.status(200).json({
         success: true,
         message: "피드백 조회 성공",

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -121,7 +121,8 @@ const updateFeedback = async (req, res, next) => {
               content: content,
               start_content: start_content
             },
-            { where: {
+            { 
+                where: {
                 id: feedback_id
             }
         })
@@ -132,7 +133,7 @@ const updateFeedback = async (req, res, next) => {
                         model: reflection,
                     },
                     {
-                    model: user
+                        model: user
                     }]
             });
 

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -1,4 +1,5 @@
-const {user, team, userteam, reflection, feedback} = require('../../models');
+const {user, team, userteam, reflection, feedback, sequelize} = require('../../models');
+const { Op } = require("sequelize");
 
 // request data : user_id, team_id, reflection_id, feedback information(type, keyword, content, to_id, start_content)
 // response data : feedback information(type, keyword, content, from_id, to_id, is_favorite, start_content)
@@ -175,10 +176,57 @@ const deleteFeedback = async (req, res, next) => {
         })
     }
 }
- 
+
+//* request data: team_id, reflection_id
+//* query string: members
+//* reponse data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
+//* 회고의 특정 유저와 유저가 속한 팀의 피드백을 분류하여 조회하는 API
+const getTeamAndUserFeedback = async (req, res) => {
+
+    try {
+        const member_id = req.query.members;
+        const { team_id, reflection_id } = req.params
+
+    const userFeedbackData = await feedback.findAll({
+        where: {
+            team_id: team_id,
+            reflection_id: reflection_id,
+            from_id: member_id
+        }
+    });
+
+    const teamFeedbackData = await feedback.findAll({
+        where: {
+            team_id: team_id,
+            reflection_id: reflection_id,
+            from_id: {
+                [Op.ne]: member_id
+            }
+        }
+    })
+    console.log(teamFeedbackData);
+    return res.status(200).json({
+        success: true,
+        message: "피드백 조회 성공",
+        data: {
+            user_feedback: userFeedbackData,
+            team_feedback: teamFeedbackData 
+        }
+    })
+    } catch (error) {
+        return res.status(400).json({
+            success: true,
+            message: "피드백 조회 실패",
+            data: error.message
+        })
+    }
+    
+};
+
 module.exports = {
     createFeedback,
     getCertainTypeFeedbackAll,
     updateFeedback,
-    deleteFeedback
+    deleteFeedback,
+    getTeamAndUserFeedback
 };

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -13,5 +13,5 @@ router.post('/', createFeedback);
 router.get('/', getCertainTypeFeedbackAll);
 router.put('/:feedback_id', updateFeedback);
 router.delete("/:feedback_id", deleteFeedback);
-router.get("/category", getTeamAndUserFeedback); 
+router.get("/from_team", getTeamAndUserFeedback); 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -13,5 +13,5 @@ router.post('/', createFeedback);
 router.get('/', getCertainTypeFeedbackAll);
 router.put('/:feedback_id', updateFeedback);
 router.delete("/:feedback_id", deleteFeedback);
-router.get("/from_team", getTeamAndUserFeedback); 
+router.get("/from-team", getTeamAndUserFeedback); 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -4,11 +4,14 @@ const {
     createFeedback,
     getCertainTypeFeedbackAll,
     updateFeedback,
-    deleteFeedback
+    deleteFeedback,
+    getTeamAndUserFeedback
+
 } = require('./feedbacks');
 
 router.post('/', createFeedback);
 router.get('/', getCertainTypeFeedbackAll);
 router.put('/:feedback_id', updateFeedback);
 router.delete("/:feedback_id", deleteFeedback);
+router.get("/category", getTeamAndUserFeedback); 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -2,10 +2,12 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
     getCurrentReflectionDetail,
-    getPastReflectionList
+    getPastReflectionList,
+    endInProgressReflection
 } = require('./reflections');
 
 router.get('/current', getCurrentReflectionDetail);
 router.get('/', getPastReflectionList);
+router.patch("/:reflection_id/end", endInProgressReflection);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -1,5 +1,4 @@
-const { equal } = require('assert');
-const {user, team, userteam, reflection, feedback} = require('../../models');
+const {user, team, reflection, feedback} = require('../../models');
 
 // request data : user_id, team_id
 // response data : current_reflection_id, reflection_name, date, status, 회고에 속한 keywords 목록

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -99,6 +99,21 @@ const endInProgressReflection = async (req, res, next) => {
             })
         const data = await reflection.findByPk(reflection_id);
 
+        const newReflectionData = await reflection.create({
+            team_id: team_id
+        })
+        console.log(`newReflectionData : ${newReflectionData.id}`);
+
+        const updateTeamCurrentReflectionId = await team.update(
+            {
+                current_reflection_id: newReflectionData.id
+            },
+            {
+                where: {
+                    id: team_id
+                }
+            });
+
         return res.status(200).json({
             success: true,
             message: "회고 종료 성공",
@@ -109,7 +124,7 @@ const endInProgressReflection = async (req, res, next) => {
     } catch (error) {
         return res.status(400).json({
             success: false,
-            message: "회고 종료 실패"
+            message: error.message
         })
     }
     

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -81,9 +81,12 @@ const getPastReflectionList = async (req, res, next) => {
     }
 }
 
+//* request data: reflection_id, team_id
+//* response data: id, reflection_name, date, state, team_id
+//* 특정 회고를 종료하는 API
 const endInProgressReflection = async (req, res, next) => {
     try {
-        const { reflection_id } = req.params;
+        const { reflection_id, team_id } = req.params;
 
         await reflection.update(
             {
@@ -91,7 +94,8 @@ const endInProgressReflection = async (req, res, next) => {
             },
             {
                 where:{
-                    id: reflection_id
+                    id: reflection_id,
+                    team_id: team_id
                     }
             })
         const data = await reflection.findByPk(reflection_id);

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -1,3 +1,4 @@
+const { equal } = require('assert');
 const {user, team, userteam, reflection, feedback} = require('../../models');
 
 // request data : user_id, team_id
@@ -80,8 +81,40 @@ const getPastReflectionList = async (req, res, next) => {
     }
 }
 
+const endInProgressReflection = async (req, res, next) => {
+    try {
+        const { reflection_id } = req.params;
+
+        await reflection.update(
+            {
+                state: "Done"
+            },
+            {
+                where:{
+                    id: reflection_id
+                    }
+            })
+        const data = await reflection.findByPk(reflection_id);
+
+        return res.status(200).json({
+            success: true,
+            message: "회고 종료 성공",
+            data: {
+                reflection: data
+            }
+        })
+    } catch (error) {
+        return res.status(400).json({
+            success: false,
+            message: "회고 종료 실패"
+        })
+    }
+    
+}
+
 
 module.exports = {
     getCurrentReflectionDetail,
-    getPastReflectionList
+    getPastReflectionList,
+    endInProgressReflection
 };


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- [x] : 특정 회고 종료 API 구현
- [x] : 특정 팀의 피드백 데이터 분류해서 조회 API 구현

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 특정 회고 종료 API 구현
  - 회고 상태를 'Done'으로 변경하는 구현
- 특정 팀의 피드백 데이터를 분류해서 조회 API구현
  - user id를 기준으로, user의 피드백과 user의 피드백을 제외한 team의 데이터를 분류하여, reponse로 뿌려준다.
  
## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- Postman으로 API test
PATCH http://localhost:3000/teams/1/reflections/2/end


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- 회고 종료 API
<img width="618" alt="image" src="https://user-images.githubusercontent.com/81692211/201530427-f5d39391-38b3-43a6-8502-6bc2313829b9.png">

- 피드백 조회 API

<img width="724" alt="image" src="https://user-images.githubusercontent.com/81692211/201530471-f6559ae9-9c3b-472f-a66d-8ffed24e8d73.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #35 

- 엔드포인트가 기존에 있던 진행했던 회고 API 구현과 일치하여, 엔드포인트를 임시로
/teams/{team_id}/reflections/{reflection_id}/feedbacks/category/?members={member_id} 으로 수정했습니다. 논의 후 수정이 필요할 것 같습니다.


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
