### PR TITLE
[FEAT] middleware 구현 - 회고의 상태 검증

### DIFF
--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -22,9 +22,9 @@ app.get('/', (req, res) => {
 });
 
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
-app.use('/users', require('./routes/users/index'));
-app.use('/teams', require('./routes/teams/index'));
-app.use('/teams/:team_id/reflections', require('./routes/reflections/index'));
-app.use('/teams/:team_id/reflections/:reflection_id/feedbacks', require('./routes/feedbacks/index'));
+app.use('api/v1/users', require('./routes/users/index'));
+app.use('api/v1/teams', require('./routes/teams/index'));
+app.use('api/v1/teams/:team_id/reflections', require('./routes/reflections/index'));
+app.use('api/v1/teams/:team_id/reflections/:reflection_id/feedbacks', require('./routes/feedbacks/index'));
 
 module.exports = app

--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -10,11 +10,11 @@ app.use(express.json());
 // database 연결
 sequelize.sync({ force: false })
 .then(() => {
-    console.log('데이터베이스 연결 성공');
+    // console.log('데이터베이스 연결 성공');
 })
 .catch((err) => {
-    console.log('데이터베이스 연결 실패');
-    console.error(err);
+    // console.log('데이터베이스 연결 실패');
+    // console.error(err);
 });
 
 app.get('/', (req, res) => {

--- a/Maddori.Apple-Server/bin/www
+++ b/Maddori.Apple-Server/bin/www
@@ -26,7 +26,7 @@
   * Listen on provided port, on all network interfaces.
   */
  server.listen(port, () => {
-    console.log(`App listening on port ${port}`)
+    // console.log(`App listening on port ${port}`)
  });
  server.on('error', onError);
  server.on('listening', onListening);
@@ -65,11 +65,11 @@
    // handle specific listen errors with friendly messages
    switch (error.code) {
      case 'EACCES':
-       console.error(`${bind} requires elevated privileges`);
+      //  console.error(`${bind} requires elevated privileges`);
        process.exit(1);
        break;
      case 'EADDRINUSE':
-       console.error(`${bind} is already in use`);
+      //  console.error(`${bind} is already in use`);
        process.exit(1);
        break;
      default:

--- a/Maddori.Apple-Server/config/config.js
+++ b/Maddori.Apple-Server/config/config.js
@@ -7,7 +7,13 @@ const development = {
     database: env.DB_DATABASE,
     host: env.DB_HOST,
     dialect: "mysql",
-    port: env.DB_PORT || "3306"
+    dialectOptions: {
+        dateStrings: true,
+        typeCast: true
+        // useUTC: false, // for reading from database
+    },
+    port: env.DB_PORT || "3306",
+    timezone: "+09:00"
 };
 
 module.exports = { development };

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -51,7 +51,35 @@ const userAdminCheck = async (req, res, next) => {
     }
 }
 
+const reflectionStateCheck = (requiredState) => {
+    return async (req, res, next) => {
+        try {
+            console.log('회고의 상태 검증');
+            const { team_id, reflection_id } = req.params;
+            const reflectionState = await reflection.findOne({
+                attributes: ['state'],
+                where: {
+                    id: reflection_id,
+                    team_id: team_id
+                },
+                raw: true
+            });
+            console.log(reflectionState);
+            if (reflectionState.state !== requiredState) throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`);
+            next();
+
+        } catch (error) {
+            res.status(400).json({
+                success: false,
+                message: '요청 권한 없음',
+                detail: error.message
+            });
+        }
+    }
+}
+
 module.exports = {
     userTeamCheck,
-    userAdminCheck
+    userAdminCheck,
+    reflectionStateCheck
 }

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -103,7 +103,7 @@ const reflectionStateCheck = (requiredState) => {
                 },
                 raw: true
             });
-            if (reflectionState.state !== requiredState) throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`);
+            if (reflectionState.state !== requiredState && reflectionState.state != 'SettingRequired') throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`);
             next();
 
         } catch (error) {

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -4,7 +4,7 @@ const {user, team, userteam, reflection, feedback, sequelize} = require('../mode
 
 const userTeamCheck = async (req, res, next) => {
     try {
-        console.log('유저의 팀 검증');
+        // console.log('유저의 팀 검증');
         const user_id = req.header('user_id');
         const { team_id, ...other } = req.params;
 
@@ -29,7 +29,7 @@ const userTeamCheck = async (req, res, next) => {
 
 const userAdminCheck = async (req, res, next) => {
     try {
-        console.log('유저의 현재 팀 리더 검증');
+        // console.log('유저의 현재 팀 리더 검증');
         const user_id = req.header('user_id');
         const { team_id, ...other } = req.params;
 
@@ -55,7 +55,7 @@ const userAdminCheck = async (req, res, next) => {
 
 const reflectionTimeCheck = async (req, res, next) => {
     try {
-        console.log('회고 일정 체크');
+        // console.log('회고 일정 체크');
         let { team_id, reflection_id } = req.params;
 
         // 팀에서 진행 중인 현재 회고의 reflection_id 구하기
@@ -92,7 +92,7 @@ const reflectionTimeCheck = async (req, res, next) => {
 const reflectionStateCheck = (requiredState) => {
     return async (req, res, next) => {
         try {
-            console.log('회고의 상태 검증');
+            // console.log('회고의 상태 검증');
             let { team_id, reflection_id } = req.params;
 
             // 팀에서 진행 중인 현재 회고의 reflection_id 구하기

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -60,8 +60,6 @@ const reflectionStateCheck = (requiredState) => {
             const { team_id, reflection_id } = req.params;
 
             // 회고의 Before 상태를 요구한다면 회고 일정 지났는지 체크, 지났다면 상태 변경
-            // const nowDate = new Date();
-            // console.log(nowDate);
             if (requiredState === 'Before') {
                 const updateReflectionState = await reflection.update({
                     state: 'Progressing'
@@ -73,7 +71,6 @@ const reflectionStateCheck = (requiredState) => {
                     },
                     raw: true
                 });
-                // console.log(updateReflectionState);
             }
 
             // 회고의 상태 구하기
@@ -84,7 +81,6 @@ const reflectionStateCheck = (requiredState) => {
                 },
                 raw: true
             });
-            // console.log(reflectionState.date);
             if (reflectionState.state !== requiredState) throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`);
             next();
 

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -129,7 +129,7 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
             },
             raw: true
         });
-        console.log(currentReflection);
+        // console.log(currentReflection);
 
         // 피드백을 받는 멤버의 정보 가져오기 (받는 멤버의 정보가 없을 경우 에러 처리)
         const membersDetail = await user.findByPk(members);

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -8,12 +8,13 @@ const {
 } = require('./feedbacks');
 const {
     userTeamCheck,
-    userAdminCheck
+    userAdminCheck,
+    reflectionStateCheck
 } = require('../../middlewares/auth');
 
-router.post('/', [userTeamCheck], createFeedback);
+router.post('/', [userTeamCheck, reflectionStateCheck('Before')], createFeedback);
 router.get('/', [userTeamCheck], getCertainTypeFeedbackAll);
-router.put('/:feedback_id', updateFeedback);
-router.delete("/:feedback_id", deleteFeedback);
+router.put('/:feedback_id', [userTeamCheck, reflectionStateCheck('Before')], updateFeedback);
+router.delete("/:feedback_id", [userTeamCheck, reflectionStateCheck('Before')], deleteFeedback);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -9,12 +9,13 @@ const {
 const {
     userTeamCheck,
     userAdminCheck,
+    reflectionTimeCheck,
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
-router.post('/', [userTeamCheck, reflectionStateCheck('Before')], createFeedback);
+router.post('/', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('Before')], createFeedback);
 router.get('/', [userTeamCheck], getCertainTypeFeedbackAll);
-router.put('/:feedback_id', [userTeamCheck, reflectionStateCheck('Before')], updateFeedback);
-router.delete("/:feedback_id", [userTeamCheck, reflectionStateCheck('Before')], deleteFeedback);
+router.put('/:feedback_id', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('Before')], updateFeedback);
+router.delete("/:feedback_id", [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('Before')], deleteFeedback);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -7,11 +7,12 @@ const {
 } = require('./reflections');
 const {
     userTeamCheck,
-    userAdminCheck
+    userAdminCheck,
+    reflectionStateCheck
 } = require('../../middlewares/auth');
 
 router.get('/', [userTeamCheck], getPastReflectionList);
 router.get('/current', [userTeamCheck], getCurrentReflectionDetail);
-router.patch('/:reflection_id', [userTeamCheck, userAdminCheck], updateReflectionDetail);
+router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -8,11 +8,12 @@ const {
 const {
     userTeamCheck,
     userAdminCheck,
+    reflectionTimeCheck,
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
 router.get('/', [userTeamCheck], getPastReflectionList);
-router.get('/current', [userTeamCheck], getCurrentReflectionDetail);
-router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);
+router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);
+router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -4,7 +4,7 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // response data : current_reflection_id, reflection_name, date, status, 회고에 속한 keywords 목록
 // 팀에서 진행하는 현재의 회고 정보 가져오기
 async function getCurrentReflectionDetail(req, res, next) {
-    console.log("현재 회고 정보 가져오기");
+    // console.log("현재 회고 정보 가져오기");
 
     try {
         // 팀의 현재 회고 id
@@ -57,7 +57,7 @@ const updateReflectionDetail = async (req, res, next) => {
     // TODO: 유저가 현재 팀의 리더인지 검증(미들웨어)
     // TODO: 회고의 status가 회고 정보를 추가할 수 있는 상태인지 검증(미들웨어)
     try {
-        console.log('회고 정보 추가하기');
+        // console.log('회고 정보 추가하기');
         const { reflection_id } = req.params;
         const { reflection_name, reflection_date } = req.body;
 

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -20,7 +20,7 @@ function checkDuplicateCode(createdTeamCode) {
         }
     });
     if (duplicateCode == null) {
-        console.log("Code duplicate");
+        // console.log("Code duplicate");
         return true;
     }
     return false;
@@ -30,7 +30,7 @@ function checkDuplicateCode(createdTeamCode) {
 // response data : team_id, team_name, team_code 
 // 유저가 팀 생성하기 (팀의 코드 생성, 해당 유저는 팀에 합류 후 팀의 admin으로 설정, 팀의 첫번째 회고 자동 생성)
 async function createTeam(req, res, next) {
-    console.log("팀 생성하기");
+    // console.log("팀 생성하기");
     const teamContent = req.body;
     // TODO: 데이터 형식 맞지 않는 경우 에러 처리 추가
 
@@ -88,7 +88,7 @@ async function createTeam(req, res, next) {
 // response data : team_id, team_name, invitation_code, admin
 // 팀의 정보 가져오기
 async function getCertainTeamDetail(req, res, next) {
-    console.log("팀의 정보 가져오기");
+    // console.log("팀의 정보 가져오기");
 
     try {
         // 팀의 team_name, invitation_code
@@ -130,7 +130,7 @@ async function getCertainTeamDetail(req, res, next) {
 // response data : [user_id, username]
 // 팀에 속한 유저(멤버) 목록 가져오기
 async function getTeamMembers(req, res, next) {
-    console.log("팀 멤버 목록 가져오기");
+    // console.log("팀 멤버 목록 가져오기");
 
     try {
         // TODO : 불필요한 필드 제거 (user.username)

--- a/Maddori.Apple-Server/routes/users/index.js
+++ b/Maddori.Apple-Server/routes/users/index.js
@@ -5,9 +5,14 @@ const {
     userJoinTeam,
     userLeaveTeam
 } = require('./users');
+const {
+    userTeamCheck,
+    userAdminCheck,
+    reflectionStateCheck
+} = require('../../middlewares/auth');
 
 router.post('/login', userLogin);
 router.post('/join-team', userJoinTeam);
-router.delete('/team/:team_id/leave', userLeaveTeam);
+router.delete('/team/:team_id/leave', [userTeamCheck], userLeaveTeam);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -5,7 +5,7 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // response data : user_id, username
 // 새로운 user 생성하기
 async function userLogin(req, res, next) {
-    console.log("유저 로그인");
+    // console.log("유저 로그인");
     const userContent = req.body;
     // TODO: username 데이터 없는 경우 에러 처리 추가
 
@@ -31,7 +31,7 @@ async function userLogin(req, res, next) {
 // response data : userteam_id, user_id, team_id
 // 유저가 팀에 합류하기
 async function userJoinTeam(req, res, next) {
-    console.log("유저 팀 조인");
+    // console.log("유저 팀 조인");
     const userTeamContent = req.body;
     // TODO: 데이터 형식 맞지 않는 경우 에러 처리 추가
 
@@ -44,7 +44,7 @@ async function userJoinTeam(req, res, next) {
         });
         // 초대 코드가 일치하는 팀이 없을 경우
         if (requestTeam === null) {
-            console.log("team not found");
+            // console.log("team not found");
             // TODO: 초대 코드가 잘못 됐을 경우 에러 처리 추가
         }
         // 초대 코드가 일치하는 팀이 있는 경우, userteam 테이블 업데이트
@@ -72,7 +72,7 @@ async function userJoinTeam(req, res, next) {
 // response data : 결과 처리 여부
 // 유저가 팀을 탈퇴하기
 async function userLeaveTeam(req, res, next) {
-    console.log("유저 팀 탈퇴");
+    // console.log("유저 팀 탈퇴");
     
     try {
         const deletedUserTeam = await userteam.destroy({


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
피드백 내용을 수정, 삭제, 등록할 때 회고의 상태가 'Before(회고 진행 이전)'이어야 합니다.
리더가 회고의 정보를 추가할 때 회고의 상태가 'SettingRequired(이름, 날짜 세팅 필요)'이어야 합니다.

원하는 회고 상태에 적합한지 검증하는 미들웨어를 구현하고, 이를 필요로 하는 api에 미들웨어를 적용했습니다.
또한 회고나 피드백에 대한 request를 보낼 때마다 회고 일정이 지났는지를 판단하고, 일정이 지났다면 회고 state를 업데이트 해주는 미들웨어를 구현했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회고 상태 검증 middleware 구현
- createFeedback, updateFeedback, deleteFeedback, updateReflectionDetail API에 미들웨어 적용
   미들웨어를 호출할 때 parameter로 요구하는 회고의 state 값('SettingRequired' || 'Before' || 'InProgress' || 'Done') 을 넘겨줍니다.
   미들웨어에서는 reflection의 실제 state값과 요구된 state 값을 비교하여, 일치하지 않을 경우 에러를 반환하고 요청 수행을 중단합니다.
- 회고 일정 검증 middleware 구현
   회고의 일정과 현재 시간을 비교하고, 일정이 현재 시간 전이라면 회고 state를 Progressing으로 업데이트합니다.
   회고 일정 검증과 상태 검증이 모두 이루어지는 경우 일정검증 -> 상태 검증 순으로 이루어집니다.
## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- createFeedback, updateFeedback, deleteFeedback, updateReflectionDetail API 수행시 회고 상태가 요청에 적합하지 않으면 에러를 반환합니다. 

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- 회고 상태로 인한 에러가 발생한 경우
<img width="571" alt="image" src="https://user-images.githubusercontent.com/67336936/201572166-d0f10ffe-f326-4c05-aa2d-8f36d88e0ede.png">
현재 회고 상태 값과 함께 에러를 반환합니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이후 진행 중인 회고 종료와 같이 회고의 상태 검증이 필요한 경우 이 pr에서 구현된 reflectionStateCheck 미들웨어를 적용해주셔야 합니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #22 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
