### PR TITLE
[CHORE] getCertainTeamDetail admin boolean으로 반환하도록 수정(#48)

### DIFF
--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -110,7 +110,7 @@ async function getCertainTeamDetail(req, res, next) {
             team_id: parseInt(team_id),
             team_name: teamBasicInformation.team_name,
             invitation_code: teamBasicInformation.invitation_code,
-            admin: teamLeader.admin
+            admin: teamLeader.admin === 0 ? false : true
         }
 
         res.status(200).json({


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
admin 필드가 boolean이 아닌 1과 0으로 response가 되고 있었습니다. 따라서 이를 boolean 형식으로 변경하였습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 삼항연산자를 사용한 boolean 형식으로의 변경

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- getCertainTeamDetail api 실행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="628" alt="image" src="https://user-images.githubusercontent.com/67336936/202178176-50258adb-5d4a-4e3d-bc65-0090210d9941.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
간단한 코드 수정이라 바로 머지하겠습니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
