### PR TITLE
[FEAT] user join team api 분리

### DIFF
--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
     createTeam,
+    getCertainTeamName,
     getCertainTeamDetail,
     getTeamMembers
 } = require('./teams');
@@ -10,6 +11,7 @@ const {
     userAdminCheck
 } = require('../../middlewares/auth');
 
+router.get('/', getCertainTeamName);
 router.post('/', createTeam);
 router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);
 router.get('/:team_id/members', [userTeamCheck], getTeamMembers);

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -84,6 +84,40 @@ async function createTeam(req, res, next) {
     }
 }
 
+// request data : user_id, team_code
+// response date : team_id, team_name
+// 팀 코드를 통해 해당 팀의 이름을 찾는다. 일치하는 팀이 없을 경우 에러를 반환한다.
+const getCertainTeamName = async (req, res, next) => {
+    try {
+        const user_id = req.header('user_id');
+        const { invitation_code } = req.query;
+        const requestTeam = await team.findOne({
+            attributes: ['id', 'team_name'],
+            where: {
+                invitation_code: invitation_code
+            },
+            raw: true
+        });
+        // 초대 코드가 일치하는 팀이 없을 경우
+        if (requestTeam === null) {
+            throw Error('초대 코드가 잘못됨');
+        }
+        res.status(200).json({
+            success: true,
+            message: '팀 정보 가져오기 성공',
+            detail: requestTeam
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '팀 정보 가져오기 실패',
+            detail: error.message
+        });
+    }
+} 
+
 // request data : user_id, team_id
 // response data : team_id, team_name, invitation_code, admin
 // 팀의 정보 가져오기
@@ -175,6 +209,7 @@ async function getTeamMembers(req, res, next) {
 
 module.exports = {
     createTeam,
+    getCertainTeamName,
     getCertainTeamDetail,
     getTeamMembers
 };

--- a/Maddori.Apple-Server/routes/users/index.js
+++ b/Maddori.Apple-Server/routes/users/index.js
@@ -12,7 +12,7 @@ const {
 } = require('../../middlewares/auth');
 
 router.post('/login', userLogin);
-router.post('/join-team', userJoinTeam);
+router.post('/join-team/:team_id', userJoinTeam);
 router.delete('/team/:team_id/leave', [userTeamCheck], userLeaveTeam);
 
 module.exports = router;


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
'팀 정보 response', '팀 합류' 두 가지로 기존 userJoinTeam api 분리

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 팀 정보 response api 생성 : getCertainTeamName
   팀 코드를 query string으로 받아서 코드가 일치하는 팀을 반환하도록 구현했습니다.
- 팀 합류 api 수정 : userJoinTeam
   기존에는 body로 코드를 받아서 요청 수행했지만, parameter로 team_id를 받아서 요청 수행하는 방식으로 변경하였습니다.
   팀이 존재하지 않는 경우 에러를 반환하고, 이미 유저가 팀에 합류되어있는 경우에도 에러를 반환합니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
getCertainTeamName, userJoinTeam api를 수행합니다.
api 명세를 참고해주세요.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="638" alt="image" src="https://user-images.githubusercontent.com/67336936/202189164-e6ee06da-5984-47b0-b2ea-27aee6238d0f.png">
<img width="580" alt="image" src="https://user-images.githubusercontent.com/67336936/202189340-2624d0f3-89ba-4656-87ae-40a6d0ef76d7.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- userJoinTeam 요청을 보낼 때 body가 없어도 post를 사용했는데, 실제 데이터베이스에서는 새로운 데이터 생성이 이루어지기 때문입니다.
  이런 식으로 의미에 맞게 get, post 등의 method를 지정해주는게 맞는 방식인지 잘 모르겠습니다.. 현재는 get method로 userJoinTeam을 수행해도 실행에는 전혀 지장이 없습니다.

- 일단 급한 이슈라 머지는 바로하겠습니다! 나중에 시간 되시면 한 번 읽어봐주세요!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #53


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
