### PR TITLE
[CHORE] 회고 종료 API 미들웨어 추가

### DIFF
--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -13,7 +13,7 @@ const {
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
-router.patch('/:reflection_id/end', [userAdminCheck], endInProgressReflection);
+router.patch('/:reflection_id/end', [userTeamCheck, userAdminCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
 router.get('/', [userTeamCheck], getPastReflectionList);
 router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);
 router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -13,7 +13,7 @@ const {
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
-router.patch('/:reflection_id/end', endInProgressReflection);
+router.patch('/:reflection_id/end', [userAdminCheck], endInProgressReflection);
 router.get('/', [userTeamCheck], getPastReflectionList);
 router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);
 router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 회고 종료 API에서 리더가 아니어도 회고가 보내짐.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- [x] 회고 종료 API에 리더 검증 미들웨어 추가
- [x] 회고 종료 API에 팀 검증 미들웨어 추가
- [x] 회고 종료 API에 회고 상태 검증 미들웨어 추가


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 리더인 경우
user_id : 1
http://localhost:3000/api/v1/teams/1/reflections/1/end

- 리더가 아닌 경우
user_id: 2
http://localhost:3000/api/v1/teams/1/reflections/1/end

- 회고 상태가 Progressing이 아닌 경우,
user_id : 1
http://localhost:3000/api/v1/teams/1/reflections/1/end

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="781" alt="image" src="https://user-images.githubusercontent.com/81692211/202219136-4879907d-2a88-48fe-833f-cc83037ea261.png">


<img width="827" alt="image" src="https://user-images.githubusercontent.com/81692211/202218924-db6d4718-8cca-4838-87be-a9bc263713b5.png">

<img width="1242" alt="스크린샷 2022-11-17 오전 12 41 06" src="https://user-images.githubusercontent.com/81692211/202225761-9603eb9f-7845-4eb7-a7fa-3d669deb3f23.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #55 
