### PR TITLE
[FEAT] apple login 구현

### DIFF
--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -21,6 +21,8 @@ app.get('/', (req, res) => {
   res.send('Hello World! This is KeyGo server')
 });
 
+app.get('/api/vi/login', require('./routes/auth/index'));
+
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
 app.use('/api/v1/users', require('./routes/users/index'));
 app.use('/api/v1/teams', require('./routes/teams/index'));

--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -21,7 +21,7 @@ app.get('/', (req, res) => {
   res.send('Hello World! This is KeyGo server')
 });
 
-app.get('/api/vi/login', require('./routes/auth/index'));
+app.use('/api/v1/login', require('./routes/auth/index'));
 
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
 app.use('/api/v1/users', require('./routes/users/index'));

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -1,25 +1,24 @@
 const { Op } = require('sequelize')
 const jwtUtil = require('../utils/jwt.util');
+const jwt = require('jsonwebtoken');
 const {user, team, userteam, reflection, feedback, sequelize} = require('../models');
 const secret = process.env.JWT_KEY;
 
 // 유저 정보 검증하기
 const userCheck = async (req, res, next) => {
     try {
-        console.log('유저 검증 시작');
+        // console.log('유저 검증 시작');
         // accessToken 유효한지 검증, 유효하다면 user_id 값 가져오기
-        const accessToken = req.header('access_token');
-        console.log('access token');
-        console.log(accessToken);
+        const accessToken = req.header('access_token').replace(/"/g, ''); // 따옴표 제거
         let user_id;
-        await jwtUtil.verify(accessToken).then((error, decoded) => {
-            if (error) {
+        await jwtUtil.verify(accessToken).then((result) => {
+            if (result.type === false) {
+                console.log(result.message);
                 throw Error('access_token이 유효하지 않음');
             }
-            user_id = decoded.id;
+            user_id = result.decoded.id;
         });
-        console.log('user_id');
-        console.log(user_id);
+
         // 다음 미들웨어 or 핸들러로 user_id 값 넘겨주기
         req.user_id = user_id;
         next();
@@ -29,7 +28,7 @@ const userCheck = async (req, res, next) => {
             success: false,
             message: '유저 검증 실패',
             detail: error.message
-        })
+        });
     }
 
 }

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -7,7 +7,7 @@ const secret = process.env.JWT_KEY;
 // 유저 정보 검증하기
 const userCheck = async (req, res, next) => {
     try {
-        // console.log('유저 검증 시작');
+        console.log('유저 검증 시작');
         // accessToken 유효한지 검증, 유효하다면 user_id 값 가져오기
         const accessToken = req.header('access_token').replace(/"/g, ''); // 따옴표 제거
         let user_id;
@@ -36,7 +36,7 @@ const userCheck = async (req, res, next) => {
 const userTeamCheck = async (req, res, next) => {
     try {
         // console.log('유저의 팀 검증');
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
         const { team_id, ...other } = req.params;
 
         // 요청을 보낸 유저가 요청 대상 팀(team_id)에 속해있는지 확인하기
@@ -61,7 +61,7 @@ const userTeamCheck = async (req, res, next) => {
 const userAdminCheck = async (req, res, next) => {
     try {
         // console.log('유저의 현재 팀 리더 검증');
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
         const { team_id, ...other } = req.params;
 
         // 요청을 보낸 유저가 요청 대상 팀(team_id)의 리더인지 확인하기

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -7,13 +7,13 @@ const secret = process.env.JWT_KEY;
 // 유저 정보 검증하기
 const userCheck = async (req, res, next) => {
     try {
-        console.log('유저 검증 시작');
+        // console.log('유저 검증 시작');
         // accessToken 유효한지 검증, 유효하다면 user_id 값 가져오기
         const accessToken = req.header('access_token').replace(/"/g, ''); // 따옴표 제거
         let user_id;
-        await jwtUtil.verify(accessToken).then((result) => {
+        await jwtUtil.verify(accessToken, secret).then((result) => {
             if (result.type === false) {
-                console.log(result.message);
+                // console.log(result.message);
                 throw Error('access_token이 유효하지 않음');
             }
             user_id = result.decoded.id;

--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -13,8 +13,7 @@ const userCheck = async (req, res, next) => {
         let user_id;
         await jwtUtil.verify(accessToken, secret).then((result) => {
             if (result.type === false) {
-                // console.log(result.message);
-                throw Error('access_token이 유효하지 않음');
+                throw Error(result.message);
             }
             user_id = result.decoded.id;
         });

--- a/Maddori.Apple-Server/models/user.js
+++ b/Maddori.Apple-Server/models/user.js
@@ -27,6 +27,14 @@ module.exports = function(sequelize, DataTypes){
                 },
                 onDelete: 'CASCADE',
                 hooks: true
+            }),
+            user.hasOne(models.usertoken, {
+                foreignKey: {
+                    name: 'user_id',
+                    allowNull: false
+                },
+                onDelete: 'CASCADE',
+                hooks: true
             })
         }
     }

--- a/Maddori.Apple-Server/models/user.js
+++ b/Maddori.Apple-Server/models/user.js
@@ -42,7 +42,17 @@ module.exports = function(sequelize, DataTypes){
             username: {
                 field: "username",
                 type: DataTypes.STRING(6),
-                allowNull: false
+                allowNull: true
+            },
+            email: {
+                field: "email",
+                type: DataTypes.STRING,
+                allowNull: true
+            },
+            sub: {
+                field: "sub",
+                type: DataTypes.STRING,
+                allowNull: true
             }
         }, {
             sequelize,

--- a/Maddori.Apple-Server/models/usertoken.js
+++ b/Maddori.Apple-Server/models/usertoken.js
@@ -1,0 +1,42 @@
+'use strict';
+const { Model } = require("sequelize");
+
+module.exports = function(sequelize, DataTypes){
+    class usertoken extends Model { 
+        static associate(models) {
+            models.usertoken.belongsTo(models.user, {
+                foreignKey: {
+                    name: 'user_id',
+                    allowNull: false,
+                },
+                onDelete: 'CASCADE',
+                hooks: true
+            })
+        }
+    }
+
+    usertoken.init(
+        {
+            id: {
+                field: "id",
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            refresh_token: {
+                field: "refresh_token",
+                type: DataTypes.STRING,
+                allowNull: false
+            }
+        }, {
+            sequelize,
+            modelName: "usertoken",
+            timestamps: false,
+            freezeTableName: true,
+            charset: "utf8mb4",
+            collate: "utf8mb4_general_ci",
+            underscored: true
+        }
+    );
+    return usertoken;
+}

--- a/Maddori.Apple-Server/package-lock.json
+++ b/Maddori.Apple-Server/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^4.18.2",
         "jsonwebtoken": "^8.5.1",
         "mysql2": "^2.3.3",
+        "request": "^2.88.2",
         "sequelize": "^6.25.3",
         "sequelize-cli": "^6.5.1"
       },
@@ -60,6 +61,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -100,6 +116,27 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -108,10 +145,31 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -197,6 +255,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -265,6 +328,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -317,6 +391,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -326,12 +405,31 @@
         "type": "^1.0.1"
       }
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -371,6 +469,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -554,6 +661,29 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -581,6 +711,27 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -666,6 +817,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
@@ -720,6 +879,27 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -764,6 +944,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/iconv-lite": {
@@ -889,6 +1083,16 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
     "node_modules/js-beautify": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
@@ -921,6 +1125,26 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -958,6 +1182,20 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/jwa": {
       "version": "1.4.1",
@@ -1278,6 +1516,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -1323,6 +1569,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "node_modules/pg-connection-string": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
@@ -1362,11 +1613,24 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -1414,6 +1678,54 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -1701,6 +2013,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1802,6 +2138,34 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -1852,6 +2216,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1882,6 +2254,19 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/wkx": {
@@ -1990,6 +2375,17 @@
         "negotiator": "0.6.3"
       }
     },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2018,15 +2414,51 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -2096,6 +2528,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -2147,6 +2584,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2190,6 +2635,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -2199,6 +2649,14 @@
         "type": "^1.0.1"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2206,6 +2664,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "denque": {
       "version": "2.1.0",
@@ -2231,6 +2694,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -2399,6 +2871,26 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2420,6 +2912,21 @@
         "parseurl": "~1.3.3",
         "statuses": "2.0.1",
         "unpipe": "~1.0.0"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -2483,6 +2990,14 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
@@ -2527,6 +3042,20 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2556,6 +3085,16 @@
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -2654,6 +3193,16 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
     "js-beautify": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
@@ -2674,6 +3223,26 @@
           }
         }
       }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -2706,6 +3275,17 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
       }
     },
     "jwa": {
@@ -2972,6 +3552,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -3008,6 +3593,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "pg-connection-string": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
@@ -3038,11 +3628,21 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
+    "psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.11.0",
@@ -3075,6 +3675,45 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "require-directory": {
@@ -3262,6 +3901,22 @@
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
     },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -3336,6 +3991,28 @@
         "nopt": "~1.0.10"
       }
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -3374,6 +4051,14 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -3393,6 +4078,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "wkx": {
       "version": "0.5.0",

--- a/Maddori.Apple-Server/package-lock.json
+++ b/Maddori.Apple-Server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "jsonwebtoken": "^8.5.1",
         "mysql2": "^2.3.3",
         "sequelize": "^6.25.3",
         "sequelize-cli": "^6.5.1"
@@ -170,6 +171,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -365,6 +371,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/editorconfig": {
       "version": "0.15.3",
@@ -919,10 +933,90 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/long": {
       "version": "4.0.0",
@@ -1983,6 +2077,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2132,6 +2231,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "editorconfig": {
       "version": "0.15.3",
@@ -2577,10 +2684,88 @@
         "universalify": "^2.0.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "long": {
       "version": "4.0.0",

--- a/Maddori.Apple-Server/package.json
+++ b/Maddori.Apple-Server/package.json
@@ -23,6 +23,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^8.5.1",
     "mysql2": "^2.3.3",
+    "request": "^2.88.2",
     "sequelize": "^6.25.3",
     "sequelize-cli": "^6.5.1"
   },

--- a/Maddori.Apple-Server/package.json
+++ b/Maddori.Apple-Server/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "jsonwebtoken": "^8.5.1",
     "mysql2": "^2.3.3",
     "sequelize": "^6.25.3",
     "sequelize-cli": "^6.5.1"

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -1,46 +1,47 @@
-const {user, team, reflection, feedback } = require('../../models');
-const jwt = require('../../utils/jwt.util');
+const {user, team, userteam, reflection, feedback } = require('../../models');
+const jwtUtil = require('../../utils/jwt.util');
+const jwt = require('jsonwebtoken');
 // const request = require('request'); // TODO: 추후 적용
 
-const socialLogin = async (req, res, next) => {
+const appleLogin = async (req, res, next) => {
     // code : authorization code, token : identity token
     // TODO : authorization code 받아오기 (apple 공식키 사용 token 생성 전환시 사용)
     const { token } = req.body;
     console.log('로그인 요청');
     try {
-        // TODO : 공개키 가져오기 적용
-        // request.get('https://appleid.apple.com/auth/keys', function(error, response, body) {
-
-        // });
-
         // TODO : 알맞은 공개키 찾아 decoding에 적용하기
         // identity token 값에서 user 정보 가져오기
-
         const { email, sub, ...others } = jwt.decode(token);
-
-        console.log(jwt.decode(token));
     
         // 이미 있는 user인지 확인하기
-        const [loginedUser, created] = user.findOrCreate({
-            attributes: ['id', 'username', 'team_id'],
+        const [loginedUser, created] = await user.findOrCreate({
+            // attributes: ['id', 'username', 'userteam.team_id'],
             where: {
                 sub: sub,
                 email: email
             },
+            defaults: {
+                sub: sub,
+                email: email
+            },
             include: {
-                model: userteam,
-                required: true
-            }
+                attributes: ['team_id'],
+                model: userteam         
+            },
+            raw: true
         });
-        
+
         console.log(loginedUser);
 
         // token 생성
-        const accessToken = jwt.sign(loginedUser.id);
-        const refreshToken = jwt.refresh(); // TODO: refresh token db에 저장하기
-
-        console.log(accessToken);
-        console.log(refreshToken);
+        let accessToken;
+        let refreshToken;
+        await jwtUtil.sign(loginedUser.id).then((result) => {
+            accessToken = result;
+        })
+        await jwtUtil.refresh(loginedUser.id).then((result) => { // TODO: refresh token db에 저장하기
+            refreshToken = result;
+        })
         
         // 이미 있는 user일 경우
         if (created === false) {
@@ -52,30 +53,28 @@ const socialLogin = async (req, res, next) => {
                     access_token: accessToken,
                     refresh_token: refreshToken,
                     user: {
-                        id: loginedUser.id,
+                        // id: loginedUser.id,
                         username: loginedUser.username ?? null,
-                        team_id: loginedUser.team_id ?? null    
+                        team_id: loginedUser['userteams.team_id'] ?? null    
+                    }
+                }
+            });
+        } else {
+            // 새로 생성된 user일 경우
+            res.status(200).json({
+                success: true,
+                message: '유저 회원가입과 로그인 성공',
+                detail: {
+                    created: true,
+                    access_token: accessToken,
+                    refresh_token: refreshToken,
+                    user: {
+                        username: null,
+                        team_id: null    
                     }
                 }
             });
         }
-        // 새로 생성된 user일 경우
-        res.status(200).json({
-            success: true,
-            message: '유저 회원가입/로그인 성공',
-            detail: {
-                created: true,
-                access_token: accessToken,
-                refresh_token: refreshToken,
-                user: {
-                    id: loginedUser.id,
-                    username: null,
-                    team_id: null    
-                }
-            }
-        });
-
-        res.status(200).json(sub);
 
     } catch (error) {
         // TODO: 에러 처리 수정
@@ -90,5 +89,5 @@ const socialLogin = async (req, res, next) => {
 
 
 module.exports = {
-    socialLogin
+    appleLogin
 }

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -14,7 +14,12 @@ const appleLogin = async (req, res, next) => {
         let publicKeyPem;
         await jwtUtil.generateKey(token).then((result) => {
             if (result.type === false) {
-                throw Error('public key 생성 실패');
+                // public key 생성 오류는 서버 에러로 처리
+                res.status(500).json({
+                    success: false,
+                    message: '유저 로그인 실패',
+                    detail: '서버 오류'
+                })
             }
             publicKeyPem = result.key;
         });

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -1,0 +1,58 @@
+const {user, team, reflection, feedback } = require('../../models');
+const jwt = require('../../utils/jwt.util');
+const request = require('request');
+const { restart } = require('nodemon');
+
+const socialLogin = async (req, res, next) => {
+    // code : authorization code, token : identity token
+    const { code, token } = req.body;
+    try {
+        // 공개키 가져오기
+        // request.get('https://appleid.apple.com/auth/keys', function(error, response, body) {
+
+        // });
+        // identity token 값에서 user 정보 가져오기
+        const { email, sub, ...others } = jwt.decode(token);
+    
+        // 이미 있는 user인지 확인하기
+        const loginedUser = user.findOrCreate({
+            attributes: ['id', 'username', 'team_id'],
+            where: {
+                sub: sub
+            },
+            include: {
+                model: userteam,
+                required: true
+            }
+        });
+        // // 이미 있는 user : user 정보 return
+        // if (loginedUser !== null) {
+        //     res.status(200).json({
+        //         success: true,
+        //         message: '유저 로그인 성공',
+        //         detail: {
+        //             created : false,
+        //             user: loginedUser
+        //         }
+        //     });
+        // }
+        
+
+
+        res.status(200).json(sub);
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(500).json({
+            success: false,
+            message: '로그인 처리 실패',
+            detail: error.message
+        });
+    }
+}
+
+
+
+module.exports = {
+    socialLogin
+}

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -15,6 +15,7 @@ const socialLogin = async (req, res, next) => {
 
         // TODO : 알맞은 공개키 찾아 decoding에 적용하기
         // identity token 값에서 user 정보 가져오기
+
         const { email, sub, ...others } = jwt.decode(token);
 
         console.log(jwt.decode(token));

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -15,7 +15,7 @@ const appleLogin = async (req, res, next) => {
         await jwtUtil.generateKey(token).then((result) => {
             if (result.type === false) {
                 // public key 생성 오류는 서버 에러로 처리
-                res.status(500).json({
+                return res.status(500).json({
                     success: false,
                     message: '유저 로그인 실패',
                     detail: '서버 오류'
@@ -26,7 +26,6 @@ const appleLogin = async (req, res, next) => {
 
         // 공개키를 사용한 identity token 검증 및 identity token 값에서 user 정보 가져오기
         let decoded;
-        console.log(jwt.decode(token));
         await jwtUtil.verify(token, publicKeyPem).then((result) => {
             if (result.type === false) {
                 throw Error(result.message);
@@ -77,7 +76,7 @@ const appleLogin = async (req, res, next) => {
                 }
             });
 
-            res.status(200).json({
+            return res.status(200).json({
                 success: true,
                 message: '유저 로그인 성공',
                 detail: {
@@ -98,7 +97,7 @@ const appleLogin = async (req, res, next) => {
                 refresh_token: refreshToken
             });
 
-            res.status(200).json({
+            return res.status(200).json({
                 success: true,
                 message: '유저 회원가입과 로그인 성공',
                 detail: {

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -1,43 +1,78 @@
 const {user, team, reflection, feedback } = require('../../models');
 const jwt = require('../../utils/jwt.util');
-const request = require('request');
-const { restart } = require('nodemon');
+// const request = require('request'); // TODO: 추후 적용
 
 const socialLogin = async (req, res, next) => {
     // code : authorization code, token : identity token
-    const { code, token } = req.body;
+    // TODO : authorization code 받아오기 (apple 공식키 사용 token 생성 전환시 사용)
+    const { token } = req.body;
+    console.log('로그인 요청');
     try {
-        // 공개키 가져오기
+        // TODO : 공개키 가져오기 적용
         // request.get('https://appleid.apple.com/auth/keys', function(error, response, body) {
 
         // });
+
+        // TODO : 알맞은 공개키 찾아 decoding에 적용하기
         // identity token 값에서 user 정보 가져오기
         const { email, sub, ...others } = jwt.decode(token);
+
+        console.log(jwt.decode(token));
     
         // 이미 있는 user인지 확인하기
-        const loginedUser = user.findOrCreate({
+        const [loginedUser, created] = user.findOrCreate({
             attributes: ['id', 'username', 'team_id'],
             where: {
-                sub: sub
+                sub: sub,
+                email: email
             },
             include: {
                 model: userteam,
                 required: true
             }
         });
-        // // 이미 있는 user : user 정보 return
-        // if (loginedUser !== null) {
-        //     res.status(200).json({
-        //         success: true,
-        //         message: '유저 로그인 성공',
-        //         detail: {
-        //             created : false,
-        //             user: loginedUser
-        //         }
-        //     });
-        // }
         
+        console.log(loginedUser);
 
+        // token 생성
+        const accessToken = jwt.sign(loginedUser.id);
+        const refreshToken = jwt.refresh(); // TODO: refresh token db에 저장하기
+
+        console.log(accessToken);
+        console.log(refreshToken);
+        
+        // 이미 있는 user일 경우
+        if (created === false) {
+            res.status(200).json({
+                success: true,
+                message: '유저 로그인 성공',
+                detail: {
+                    created: false,
+                    access_token: accessToken,
+                    refresh_token: refreshToken,
+                    user: {
+                        id: loginedUser.id,
+                        username: loginedUser.username ?? null,
+                        team_id: loginedUser.team_id ?? null    
+                    }
+                }
+            });
+        }
+        // 새로 생성된 user일 경우
+        res.status(200).json({
+            success: true,
+            message: '유저 회원가입/로그인 성공',
+            detail: {
+                created: true,
+                access_token: accessToken,
+                refresh_token: refreshToken,
+                user: {
+                    id: loginedUser.id,
+                    username: null,
+                    team_id: null    
+                }
+            }
+        });
 
         res.status(200).json(sub);
 

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -15,7 +15,6 @@ const appleLogin = async (req, res, next) => {
     
         // 이미 있는 user인지 확인하기
         const [loginedUser, created] = await user.findOrCreate({
-            // attributes: ['id', 'username', 'userteam.team_id'],
             where: {
                 sub: sub,
                 email: email
@@ -31,21 +30,9 @@ const appleLogin = async (req, res, next) => {
             raw: true
         });
 
-        console.log(loginedUser);
-
         // token 생성
-        // let accessToken;
-        // let refreshToken;
-        // await jwtUtil.sign(loginedUser.id).then((result) => {
-        //     accessToken = result;
-        // })
-        // await jwtUtil.refresh(loginedUser.id).then((result) => { // TODO: refresh token db에 저장하기
-        //     refreshToken = result;
-        // })
-
         const accessToken = await jwtUtil.sign(loginedUser.id);
         const refreshToken = await jwtUtil.refresh(loginedUser.id);
-
         
         // 이미 있는 user일 경우
         if (created === false) {
@@ -57,7 +44,6 @@ const appleLogin = async (req, res, next) => {
                     access_token: accessToken,
                     refresh_token: refreshToken,
                     user: {
-                        // id: loginedUser.id,
                         username: loginedUser.username ?? null,
                         team_id: loginedUser['userteams.team_id'] ?? null    
                     }

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -1,37 +1,29 @@
 const {user, team, userteam, reflection, feedback, usertoken } = require('../../models');
 const jwtUtil = require('../../utils/jwt.util');
 const jwt = require('jsonwebtoken');
-// const request = require('request'); // TODO: 추후 적용
 
-// request data: authorization code, identity token
+// request data: identity token
 // response data: access_token, refresh_token, user 정보
 // apple social login을 진행하고, 토큰을 발급한다.
 const appleLogin = async (req, res, next) => {
     // TODO : authorization code 받아오기 (apple 공식키 사용 token 생성 전환시 사용)
     const { token } = req.body;
-    // console.log('로그인 요청');
+
     try {
-        // TODO : 알맞은 공개키 찾아 decoding에 적용하기
         // identity token 검증 위한 공개키 생성하기
         let publicKeyPem;
         await jwtUtil.generateKey(token).then((result) => {
             if (result.type === false) {
-                // console.log(result.message);
-                throw Error('identity token 검증 실패');
+                throw Error('public key 생성 실패');
             }
             publicKeyPem = result.key;
         });
 
-        // console.log('public key 생성 완료');
-        // console.log(publicKeyPem);
-
-        // identity token 검증 및 identity token 값에서 user 정보 가져오기
+        // 공개키를 사용한 identity token 검증 및 identity token 값에서 user 정보 가져오기
         let decoded;
         await jwtUtil.verify(token, publicKeyPem).then((result) => {
-            // console.log('verifying 시작');
             if (result.type === false) {
-                // console.log(result.message);
-                throw Error('identity token 검증 실패');
+                throw Error(result.message);
             }
             decoded = result.decoded;
         });
@@ -107,7 +99,7 @@ const appleLogin = async (req, res, next) => {
 
     } catch (error) {
         // TODO: 에러 처리 수정
-        res.status(500).json({
+        res.status(400).json({
             success: false,
             message: '유저 로그인 실패',
             detail: error.message

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -34,14 +34,18 @@ const appleLogin = async (req, res, next) => {
         console.log(loginedUser);
 
         // token 생성
-        let accessToken;
-        let refreshToken;
-        await jwtUtil.sign(loginedUser.id).then((result) => {
-            accessToken = result;
-        })
-        await jwtUtil.refresh(loginedUser.id).then((result) => { // TODO: refresh token db에 저장하기
-            refreshToken = result;
-        })
+        // let accessToken;
+        // let refreshToken;
+        // await jwtUtil.sign(loginedUser.id).then((result) => {
+        //     accessToken = result;
+        // })
+        // await jwtUtil.refresh(loginedUser.id).then((result) => { // TODO: refresh token db에 저장하기
+        //     refreshToken = result;
+        // })
+
+        const accessToken = await jwtUtil.sign(loginedUser.id);
+        const refreshToken = await jwtUtil.refresh(loginedUser.id);
+
         
         // 이미 있는 user일 경우
         if (created === false) {
@@ -80,7 +84,7 @@ const appleLogin = async (req, res, next) => {
         // TODO: 에러 처리 수정
         res.status(500).json({
             success: false,
-            message: '로그인 처리 실패',
+            message: '유저 로그인 실패',
             detail: error.message
         });
     }

--- a/Maddori.Apple-Server/routes/auth/index.js
+++ b/Maddori.Apple-Server/routes/auth/index.js
@@ -2,9 +2,9 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
 const {
-    socialLogin
+    appleLogin
 } = require('./auth');
 
-router.post('/', socialLogin);
+router.post('/', appleLogin);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/auth/index.js
+++ b/Maddori.Apple-Server/routes/auth/index.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = new express.Router({ mergeParams: true });
+
+const {
+    socialLogin
+} = require('./auth');
+
+router.post('/', socialLogin);
+
+module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -13,7 +13,7 @@ async function createFeedback(req, res, next) {
     
     try {
         // 입력 받기
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
         const { team_id, reflection_id } = req.params;
         const { type, keyword, content, start_content, to_id } = req.body;
 
@@ -51,7 +51,7 @@ async function createFeedback(req, res, next) {
 // 만약 reflection_id 가 recent인 경우에는 가장 최근 회고에서 feedback을 불러온다.
 const getCertainTypeFeedbackAll = async (req, res, next) => {
     try {
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
         const { type } = req.query;
         const { team_id, reflection_id } = req.params;
 
@@ -122,11 +122,10 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
 // 팀의 현재 회고에 담긴 피드백 중 유저가 특정 멤버에게 작성한 피드백 정보 가져오기
 const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
     // console.log('특정 멤버에게 작성한 피드백 리스트 가져오기');
-
     try {
         const { reflection_id, team_id } = req.params;
         const { members } = req.query;
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
 
         // 팀이 진행 중인 현재 회고 id 가져오기
         if (reflection_id !== 'current') throw Error('잘못된 요청 URI');
@@ -198,6 +197,7 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
 //* 특정 피드백을 수정하는 API, 현재 진행중인 회고는 수정이 불가능하다.
 const updateFeedback = async (req, res, next) => {
     try {
+        const user_id = req.user_id;
         const { feedback_id } = req.params
         const { type, keyword, content, start_content} = req.body;
 
@@ -245,6 +245,7 @@ const updateFeedback = async (req, res, next) => {
 //* 특정 피드백을 삭제하는 API
 const deleteFeedback = async (req, res, next) => {
     try {
+        const user_id = req.user_id;
         const { feedback_id } = req.params;
 
         const feedbackData = await feedback.destroy({
@@ -270,9 +271,8 @@ const deleteFeedback = async (req, res, next) => {
 //* reponse data: id, type, keyword, content, start_content, from_id, to_id, team_id, reflection_id
 //* 회고의 특정 유저와 유저가 속한 팀의 피드백을 분류하여 조회하는 API
 const getTeamAndUserFeedback = async (req, res) => {
-    const user_id = req.header('user_id');
-
     try {
+        const user_id = req.user_id;
         const member_id = req.query.members;
         const { team_id, reflection_id } = req.params
 

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -7,15 +7,18 @@ const {
     updateFeedback,
     deleteFeedback,
     getTeamAndUserFeedback
-
 } = require('./feedbacks');
 const {
+    userCheck,
     userTeamCheck,
     userAdminCheck,
     reflectionTimeCheck,
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
+// user auth 검증
+router.use('/', userCheck);
+// handler
 router.post('/', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('Before')], createFeedback);
 router.get('/', [userTeamCheck], getCertainTypeFeedbackAll);
 router.put('/:feedback_id', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('Before')], updateFeedback);

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -7,12 +7,16 @@ const {
     getPastReflectionList
 } = require('./reflections');
 const {
+    userCheck,
     userTeamCheck,
     userAdminCheck,
     reflectionTimeCheck,
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
+// user auth 검증
+router.use('/', userCheck);
+// handler
 router.patch('/:reflection_id/end', [userTeamCheck, userAdminCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
 router.get('/', [userTeamCheck], getPastReflectionList);
 router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -148,7 +148,7 @@ const endInProgressReflection = async (req, res, next) => {
         const newReflectionData = await reflection.create({
             team_id: team_id
         })
-        console.log(`newReflectionData : ${newReflectionData.id}`);
+        // console.log(`newReflectionData : ${newReflectionData.id}`);
 
         const updateTeamCurrentReflectionId = await team.update(
             {

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -7,6 +7,7 @@ async function getCurrentReflectionDetail(req, res, next) {
     // console.log("현재 회고 정보 가져오기");
 
     try {
+        const user_id = req.user_id;
         // 팀의 현재 회고 id
         const currentReflectionId = await team.findByPk(req.params.team_id, {
             attributes: ['current_reflection_id'],
@@ -58,6 +59,7 @@ const updateReflectionDetail = async (req, res, next) => {
     // TODO: 회고의 status가 회고 정보를 추가할 수 있는 상태인지 검증(미들웨어)
     try {
         // console.log('회고 정보 추가하기');
+        const user_id = req.user_id;
         const { reflection_id } = req.params;
         const { reflection_name, reflection_date } = req.body;
 
@@ -96,9 +98,10 @@ const updateReflectionDetail = async (req, res, next) => {
 //* request data: team_id
 //* response data: id, reflection_name, date, state, team_id
 const getPastReflectionList = async (req, res, next) => {
-    const { team_id } = req.params;
 
     try {
+        const user_id = req.user_id;
+        const { team_id } = req.params;
         const reflectionData = await reflection.findAll({
             where: {
                 team_id: team_id,
@@ -127,6 +130,7 @@ const getPastReflectionList = async (req, res, next) => {
 //* 특정 회고를 종료하는 API
 const endInProgressReflection = async (req, res, next) => {
     try {
+        const user_id = req.user_id;
         const { reflection_id, team_id } = req.params;
 
         await reflection.update(

--- a/Maddori.Apple-Server/routes/teams/index.js
+++ b/Maddori.Apple-Server/routes/teams/index.js
@@ -7,10 +7,14 @@ const {
     getTeamMembers
 } = require('./teams');
 const {
+    userCheck,
     userTeamCheck,
     userAdminCheck
 } = require('../../middlewares/auth');
 
+// user auth 검증
+router.use('/', userCheck);
+// handler
 router.get('/', getCertainTeamName);
 router.post('/', createTeam);
 router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);

--- a/Maddori.Apple-Server/routes/teams/teams.js
+++ b/Maddori.Apple-Server/routes/teams/teams.js
@@ -31,6 +31,7 @@ function checkDuplicateCode(createdTeamCode) {
 // 유저가 팀 생성하기 (팀의 코드 생성, 해당 유저는 팀에 합류 후 팀의 admin으로 설정, 팀의 첫번째 회고 자동 생성)
 async function createTeam(req, res, next) {
     // console.log("팀 생성하기");
+    const user_id = req.user_id;
     const teamContent = req.body;
     // TODO: 데이터 형식 맞지 않는 경우 에러 처리 추가
 
@@ -63,7 +64,7 @@ async function createTeam(req, res, next) {
 
         // 유저의 팀 합류 및 리더 설정
         const createdUserTeam = await userteam.create({
-            user_id: req.header('user_id'),
+            user_id: user_id,
             team_id: createdTeam.id,
             admin: true
         });
@@ -89,7 +90,7 @@ async function createTeam(req, res, next) {
 // 팀 코드를 통해 해당 팀의 이름을 찾는다. 일치하는 팀이 없을 경우 에러를 반환한다.
 const getCertainTeamName = async (req, res, next) => {
     try {
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
         const { invitation_code } = req.query;
         const requestTeam = await team.findOne({
             attributes: ['id', 'team_name'],
@@ -125,7 +126,7 @@ async function getCertainTeamDetail(req, res, next) {
     // console.log("팀의 정보 가져오기");
 
     try {
-        const user_id = req.header('user_id');
+        const user_id = req.user_id;
         const { team_id } = req.params;
 
         // 팀의 team_name, invitation_code
@@ -171,6 +172,7 @@ async function getTeamMembers(req, res, next) {
 
     try {
         // TODO : 불필요한 필드 제거 (user.username)
+        const user_id = req.user_id;
         // 멤버 목록 가져오기
         const teamMemberList = await userteam.findAll({
             attributes: ['user_id', 'user.username'],

--- a/Maddori.Apple-Server/routes/users/index.js
+++ b/Maddori.Apple-Server/routes/users/index.js
@@ -12,8 +12,11 @@ const {
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
-router.post('/login', [userCheck], userLogin);
-router.post('/join-team/:team_id', [userCheck], userJoinTeam);
-router.delete('/team/:team_id/leave', [userTeamCheck], userLeaveTeam);
+// user auth 검증
+router.use('/', userCheck);
+// handler
+router.post('/login', userLogin);
+router.post('/join-team/:team_id', userJoinTeam);
+router.delete('/team/:team_id/leave', userLeaveTeam);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/users/index.js
+++ b/Maddori.Apple-Server/routes/users/index.js
@@ -6,13 +6,14 @@ const {
     userLeaveTeam
 } = require('./users');
 const {
+    userCheck,
     userTeamCheck,
     userAdminCheck,
     reflectionStateCheck
 } = require('../../middlewares/auth');
 
-router.post('/login', userLogin);
-router.post('/join-team/:team_id', userJoinTeam);
+router.post('/login', [userCheck], userLogin);
+router.post('/join-team/:team_id', [userCheck], userJoinTeam);
 router.delete('/team/:team_id/leave', [userTeamCheck], userLeaveTeam);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -6,22 +6,32 @@ const {user, team, userteam, reflection, feedback} = require('../../models');
 // 새로운 user 생성하기
 async function userLogin(req, res, next) {
     // console.log("유저 로그인");
-    const userContent = req.body;
+    const user_id = req.user_id;
+    const { username } = req.body;
     // TODO: username 데이터 없는 경우 에러 처리 추가
 
     try {
-        const createdUser = await user.create(userContent);
+        // const createdUser = await user.create(userContent);
+        const updatedUser = await user.update({
+            username: username,
+            where: {
+                id: user_id
+            }
+        });
+
         res.status(201).json({
             success: true,
-            message: '유저 로그인 성공',
-            detail: createdUser
+            message: '유저 닉네임 설정 성공',
+            detail: {
+                username: username
+            }
         });
 
     } catch (error) {
         // TODO: 에러 처리 수정
         res.status(400).json({
             success: false,
-            message: '유저 로그인 실패',
+            message: '유저 닉네임 설정 실패',
             detail: error.message
         });
     }
@@ -32,7 +42,7 @@ async function userLogin(req, res, next) {
 // 유저가 팀에 합류하기
 async function userJoinTeam(req, res, next) {
     // console.log("유저 팀 조인");
-    const user_id = req.header('user_id');
+    const user_id = req.user_id;
     const { team_id } = req.params;
     // TODO: 데이터 형식 맞지 않는 경우 에러 처리 추가
 

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -11,9 +11,9 @@ async function userLogin(req, res, next) {
     // TODO: username 데이터 없는 경우 에러 처리 추가
 
     try {
-        // const createdUser = await user.create(userContent);
         const updatedUser = await user.update({
             username: username,
+        },{
             where: {
                 id: user_id
             }

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -84,13 +84,14 @@ async function userJoinTeam(req, res, next) {
 // response data : 결과 처리 여부
 // 유저가 팀을 탈퇴하기
 async function userLeaveTeam(req, res, next) {
-    // console.log("유저 팀 탈퇴");
     
     try {
+        const user_id = req.user_id;
+        const { team_id } = req.params;
         const deletedUserTeam = await userteam.destroy({
             where : {
-                user_id: req.header('user_id'),
-                team_id: req.params.team_id
+                user_id: user_id,
+                team_id: team_id
             }
         });
         // TODO: 삭제가 제대로 수행 안됐을 경우 에러 처리 추가

--- a/Maddori.Apple-Server/seeders/testData.js
+++ b/Maddori.Apple-Server/seeders/testData.js
@@ -8,19 +8,24 @@ module.exports = {
     // user table & team data
     const users = [
       {
-        username: 'Mary'
+        username: 'Mary',
+        email: 'mary@apple.com'
       },
       {
-        username: 'Ginger'
+        username: 'Ginger',
+        email: 'ginger@apple.com'
       },
       {
-        username: 'Hoya'
+        username: 'Hoya',
+        email: 'hoya@apple.com'
       },
       {
-        username: 'Chemi'
+        username: 'Chemi',
+        email: 'chemi@apple.com'
       },
       {
-        username: 'Id'
+        username: 'Id',
+        email: 'id@apple.com'
       }
     ]
     const teams = [

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -1,12 +1,13 @@
-const jwtUtil = require('jsonwebtoken');
+const jwt = require('jsonwebtoken');
 const secret = process.env.JWT_KEY;
+const request = require('request');
 
 // 새로운 access token 발급
 const sign = async (id) => {
     const payload = {
         id: id
     };
-    return jwtUtil.sign(payload, secret, { // secret으로 sign하여 발급하고 return
+    return jwt.sign(payload, secret, { // secret으로 sign하여 발급하고 return
         expiresIn: '100d',       // 유효기간
         algorithm: 'HS256', // 암호화 알고리즘
     });
@@ -14,33 +15,46 @@ const sign = async (id) => {
 
 const verify = async (token) => {
     try {
-        const decoded = jwtUtil.verify(token, secret);
+        const decoded = jwt.verify(token, secret);
         return {
             type: true,
             id: decoded.id,
         }
     } catch (error) {
-        return {
-            success: false,
-            message: error.message,
-        } 
+        return error; 
     }
 }
 
 // 새로운 refresh token 발급
 const refresh = async () => {
     try {
-        return jwtUtil.sign(payload, secret, {
+        return jwt.sign({}, secret, {
             expiresIn: '200d',
             algorithm: 'HS256',
         });
     } catch (error) {
+        return error; 
+    }
+}
 
+// token decode 하기
+const decode = async (token) => {
+    try {
+        request.get('https://appleid.apple.com/auth/keys', function(error, response, body) {
+            console.log(typeof(body));
+            const publicKey = JSON.parse(body).keys;
+            console.log(publicKey);
+        });
+        
+
+    } catch (error) {
+        return error; 
     }
 }
 
 module.exports = {
     sign,
     verify,
-    refresh
+    refresh,
+    decode
 }

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -1,0 +1,46 @@
+const jwtUtil = require('jsonwebtoken');
+const secret = process.env.JWT_KEY;
+
+// 새로운 access token 발급
+const sign = async (id) => {
+    const payload = {
+        id: id
+    };
+    return jwtUtil.sign(payload, secret, { // secret으로 sign하여 발급하고 return
+        expiresIn: '100d',       // 유효기간
+        algorithm: 'HS256', // 암호화 알고리즘
+    });
+}
+
+const verify = async (token) => {
+    try {
+        const decoded = jwtUtil.verify(token, secret);
+        return {
+            type: true,
+            id: decoded.id,
+        }
+    } catch (error) {
+        return {
+            success: false,
+            message: error.message,
+        } 
+    }
+}
+
+// 새로운 refresh token 발급
+const refresh = async () => {
+    try {
+        return jwtUtil.sign(payload, secret, {
+            expiresIn: '200d',
+            algorithm: 'HS256',
+        });
+    } catch (error) {
+
+    }
+}
+
+module.exports = {
+    sign,
+    verify,
+    refresh
+}

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -15,14 +15,17 @@ const sign = async (user_id) => {
 
 const verify = async (token) => {
     try {
-        console.log('verifying token');
-        const decoded = jwt.verify(token, secret);
+        // console.log('verifying token');
+        const decoded = jwt.verify(token, secret, {algorithm: 'RS256'});
         return {
             type: true,
-            id: decoded.id,
+            decoded: decoded,
         }
     } catch (error) {
-        return error; 
+        return {
+            type: false,
+            message: error.message
+        }      
     }
 }
 
@@ -34,7 +37,10 @@ const refresh = async () => {
             algorithm: 'HS256',
         });
     } catch (error) {
-        return error; 
+        return {
+            type: false,
+            message: error.message
+        }   
     }
 }
 
@@ -45,11 +51,13 @@ const decode = async (token) => {
             console.log(typeof(body));
             const publicKey = JSON.parse(body).keys;
             console.log(publicKey);
-        });
-        
+        }); 
 
     } catch (error) {
-        return error; 
+        return {
+            type: false,
+            message: error.message
+        }   
     }
 }
 

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -3,18 +3,19 @@ const secret = process.env.JWT_KEY;
 const request = require('request');
 
 // 새로운 access token 발급
-const sign = async (id) => {
+const sign = async (user_id) => {
     const payload = {
-        id: id
+        id: user_id
     };
     return jwt.sign(payload, secret, { // secret으로 sign하여 발급하고 return
-        expiresIn: '100d',       // 유효기간
+        expiresIn: '1y',       // 유효기간
         algorithm: 'HS256', // 암호화 알고리즘
     });
 }
 
 const verify = async (token) => {
     try {
+        console.log('verifying token');
         const decoded = jwt.verify(token, secret);
         return {
             type: true,
@@ -29,7 +30,7 @@ const verify = async (token) => {
 const refresh = async () => {
     try {
         return jwt.sign({}, secret, {
-            expiresIn: '200d',
+            expiresIn: '2y',
             algorithm: 'HS256',
         });
     } catch (error) {

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -16,7 +16,7 @@ const sign = async (user_id) => {
 const verify = async (token) => {
     try {
         // console.log('verifying token');
-        const decoded = jwt.verify(token, secret, {algorithm: 'RS256'});
+        const decoded = jwt.verify(token, secret);
         return {
             type: true,
             decoded: decoded,
@@ -33,7 +33,7 @@ const verify = async (token) => {
 const refresh = async () => {
     try {
         return jwt.sign({}, secret, {
-            expiresIn: '2y',
+            expiresIn: '10y',
             algorithm: 'HS256',
         });
     } catch (error) {

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const secret = process.env.JWT_KEY;
 const request = require('request');
+const crypto = require('crypto');
 
 // 새로운 access token 발급
 const sign = async (user_id) => {
@@ -13,10 +14,10 @@ const sign = async (user_id) => {
     });
 }
 
-const verify = async (token) => {
+const verify = async (token, key) => {
     try {
         // console.log('verifying token');
-        const decoded = jwt.verify(token, secret);
+        const decoded = jwt.verify(token, key);
         return {
             type: true,
             decoded: decoded,
@@ -44,14 +45,43 @@ const refresh = async () => {
     }
 }
 
+// reference: https://stackoverflow.com/questions/38428027/why-await-is-not-working-for-node-request-module
+// request에 대한 response가 올 때까지 기다리게 하기 위함
+function doRequest(url) {
+    return new Promise(function (resolve, reject) {
+        request(url, function (error, res, body) {
+            if (!error && res.statusCode === 200) {
+                resolve(body);
+            } else {
+                reject(error);
+            }
+        });
+    });
+}
+
 // token decode 하기
-const decode = async (token) => {
+const generateKey = async (token) => {
     try {
-        request.get('https://appleid.apple.com/auth/keys', function(error, response, body) {
-            console.log(typeof(body));
-            const publicKey = JSON.parse(body).keys;
-            console.log(publicKey);
-        }); 
+        // 공개키 리스트 가져오기
+        let response = await doRequest('https://appleid.apple.com/auth/keys');
+        const publicKeyList = JSON.parse(response).keys;
+        // token을 검증할 공개키 구하기
+        const tokenHeader = JSON.parse(Buffer.from(token.split('.')[0], 'base64').toString());
+        let publicKeyObject;
+        for (let key of publicKeyList) {
+            if (key['kid'] === tokenHeader['kid'] && key['alg'] === tokenHeader['alg']){
+                publicKeyObject = key;
+            }
+        }
+        const publicKey = crypto.createPublicKey({
+            key: publicKeyObject, format: 'jwk'
+        });
+        const pem = publicKey.export({ type: 'pkcs1', format: 'pem' });
+
+        return {
+            type: true,
+            key: pem
+        }
 
     } catch (error) {
         return {
@@ -65,5 +95,5 @@ module.exports = {
     sign,
     verify,
     refresh,
-    decode
+    generateKey
 }

--- a/Maddori.Apple-Server/utils/jwt.util.js
+++ b/Maddori.Apple-Server/utils/jwt.util.js
@@ -14,9 +14,9 @@ const sign = async (user_id) => {
     });
 }
 
+// token 검증
 const verify = async (token, key) => {
     try {
-        // console.log('verifying token');
         const decoded = jwt.verify(token, key);
         return {
             type: true,
@@ -32,17 +32,10 @@ const verify = async (token, key) => {
 
 // 새로운 refresh token 발급
 const refresh = async () => {
-    try {
-        return jwt.sign({}, secret, {
-            expiresIn: '10y',
-            algorithm: 'HS256',
-        });
-    } catch (error) {
-        return {
-            type: false,
-            message: error.message
-        }   
-    }
+    return jwt.sign({}, secret, {
+        expiresIn: '10y',
+        algorithm: 'HS256',
+    });
 }
 
 // reference: https://stackoverflow.com/questions/38428027/why-await-is-not-working-for-node-request-module
@@ -59,13 +52,14 @@ function doRequest(url) {
     });
 }
 
-// token decode 하기
+// identity token decode위한 public key 만들기
 const generateKey = async (token) => {
     try {
         // 공개키 리스트 가져오기
         let response = await doRequest('https://appleid.apple.com/auth/keys');
         const publicKeyList = JSON.parse(response).keys;
-        // token을 검증할 공개키 구하기
+
+        // identity token의 header값을 이용해 token을 검증할 공개키 JWK 선택
         const tokenHeader = JSON.parse(Buffer.from(token.split('.')[0], 'base64').toString());
         let publicKeyObject;
         for (let key of publicKeyList) {
@@ -73,6 +67,7 @@ const generateKey = async (token) => {
                 publicKeyObject = key;
             }
         }
+        // 공개키 생성
         const publicKey = crypto.createPublicKey({
             key: publicKeyObject, format: 'jwk'
         });


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
apple login을 구현하였습니다. Contents에 자세한 내용을 적어두었습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 유저 회원가입 및 로그인 api
1. client에서 request를 보냄
    POST /api/v1/login
    body에 identity_token 포함
    
2. appleLogin api 실행
    1. identity token 검증 위한 공개키 생성하기
    2. 공개키를 사용하여 identity token 검증하기
    4. identity token을 decode 하여 유저 정보 가져오기
    5. 유저 생성하기 (db 업데이트)
    6. user_id(user 테이블의 pk 값), 자체 제작 secret key를 활용해 access token, refresh token 생성하기
    7. db에 refresh token 업데이트 하기
    8. access token, refresh token, 유저 정보 응답하기

### 유저 검증 (appleLogin을 제외한 모든 api에서 수행됨) middleware
1. client에서 request를 보냄
    header에 access_token, refresh_token 포함
    
2. userCheck middleware 실행
    1. secret key를 활용해 access token 검증하기
        1. 토큰이 유효할 경우
            access_token을 decode하여 user_id 값 구하기
            request.user_id에 user_id 값 적용하여, 다음 미들웨어 or 핸들러에서 요청을 보낸 user의 user_id 값을 사용할 수 있도록 하기
        2. 토큰이 유효하지 않을 경우 (시간 만료 등)         
            '유저 검증 실패’ 에러 반환
            
    2. 토큰이 유효할 경우 api에 따른 요청 수행, 응답

### identity token : RS256 알고리즘 사용
- 검증 프로세스
    1. https://appleid.apple.com/auth/keys 에서 제공하는 JWK 배열 가져오기
    2. identity token의 header를 decode 하여 kid, alg 값 얻기
    3. JWK의 배열 중 kid, alg 값이 일치하는 JWK 활용하여 공개키 생성하기
    4. 생성한 공개키를 사용해 identity token 검증하기

### access token, refresh token : HS256 알고리즘
- token option
    현재는 access token이 만료되었을 때 refresh token을 사용해 access token을 재발급하는 프로세스를 구현하지 않은 상태입니다.
    access token만 사용하고 있기 때문에, 이번 sprint에서는 유효기간을 1년으로 길게 잡아 사용하도록 하겠습니다.
    1. access token : 유효기간 1년
    2. refresh token : 유효기간 2년

- 생성 프로세스
    secret key를 자체적으로 만들어 활용했습니다.
    1. access token : jwt.sign 활용
        payload에 user_id 넣어주기 (`{id : user_id}`)
        secret key 설정해주기
        option (유효기간, 암호화 알고리즘) 설정해주기
    2. refresh token : jwt.sign 활용
        payload에는 정보 포함하지 않음 (`{}`)
        secret key 설정해주기
        option (유효기간, 암호화 알고리즘) 설정해주기
        
- 검증 프로세스
    1. access token : jwt.verify 활용
        검증 대상 token 설정해주기
        secret key 설정해주기

### 데이터베이스
user 테이블에 애플 로그인을 통해 얻은 sub(key 값)와 email을 저장합니다.
또한 refresh token이 발급되면 usertoken 테이블에 refresh token을 저장합니다. (이는 추후 access token 재발급 과정에 활용됩니다.)
- user 테이블
<img width="698" alt="image" src="https://user-images.githubusercontent.com/67336936/203036067-1d9f2a4d-3a43-4e5a-b0c2-da702d818633.png">

- usertoken 테이블
<img width="741" alt="image" src="https://user-images.githubusercontent.com/67336936/203036203-ac685779-b1cc-427f-9503-3639514af3e9.png">



## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- appleLogin api를 실행합니다. 반환되는 access token, refresh token 값을 저장합니다.
- request를 보낼 때 (access token, refresh token)을 header에 설정합니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="765" alt="스크린샷 2022-11-21 오후 6 24 44" src="https://user-images.githubusercontent.com/67336936/203013924-0a0b3a71-8d4b-4cd9-9871-5152a20fc6eb.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재 secret key를 생성할 때 key를 만들어주는 웹 사이트를 활용했는데, 더 안전하고 좋은 키를 만드는 방법이 있을지 궁금하네요!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #50 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
[https://iu-corner.tistory.com/entry/Node-Express에서-JWT-인증-방식-직접-구현하기-Access-Token-Refresh-Token](https://iu-corner.tistory.com/entry/Node-Express%EC%97%90%EC%84%9C-JWT-%EC%9D%B8%EC%A6%9D-%EB%B0%A9%EC%8B%9D-%EC%A7%81%EC%A0%91-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-Access-Token-Refresh-Token)
[https://tlog.tammolo.com/posts/apple-login-02](https://tlog.tammolo.com/posts/apple-login-02)
[https://hello-gg.tistory.com/65](https://hello-gg.tistory.com/65)
