### PR TITLE
[FIX] timezone 설정 추가하여 회고 시간 검증 에러 해결

### DIFF
--- a/Maddori.Apple-Server/config/config.js
+++ b/Maddori.Apple-Server/config/config.js
@@ -13,7 +13,7 @@ const development = {
         // useUTC: false, // for reading from database
     },
     port: env.DB_PORT || "3306",
-    // timezone: "+09:00" //local에서는 이게 있어야 제대로 동작함
+    timezone: "+09:00"
 };
 
 module.exports = { development };


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
timezone: "+09:00" 설정이 없으면 회고 시간 검증시 시간 비교가 제대로 일어나지 않습니다.
(현재 디비 타임이 UTC 기준이기 때문. 파라미터 그룹 재설정해서 적용하면 인스턴스 재시작 필요하기 때문에 이후 디비 옮길 때 설정 부여. 현재는 임시로 이렇게 해결)
## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
timezone 설정을 추가합니다.
(서버 시간 변경 완료)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
추후에 데이터베이스 옮기는 작업이 필요한데(계정 문제로..) 시간 설정은 그 때 진행하고, 지금은 임시로 이렇게 구현하겠습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
