### PR TITLE
[FIX] 회고 일정 추가 시간 검증 기능 구현

### DIFF
--- a/Maddori.Apple-Server/config/config.js
+++ b/Maddori.Apple-Server/config/config.js
@@ -9,8 +9,8 @@ const development = {
     dialect: "mysql",
     dialectOptions: {
         dateStrings: true,
-        typeCast: true
-        // useUTC: false, // for reading from database
+        typeCast: true,
+        useUTC: false, // for reading from database
     },
     port: env.DB_PORT || "3306",
     timezone: "+09:00"

--- a/Maddori.Apple-Server/routes/reflections/index.js
+++ b/Maddori.Apple-Server/routes/reflections/index.js
@@ -16,7 +16,7 @@ const {
 router.patch('/:reflection_id/end', [userTeamCheck, userAdminCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
 router.get('/', [userTeamCheck], getPastReflectionList);
 router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);
-router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);
+router.patch('/:reflection_id', [userTeamCheck, userAdminCheck, reflectionStateCheck('SettingRequired')], updateReflectionDetail);
 
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -54,12 +54,16 @@ async function getCurrentReflectionDetail(req, res, next) {
 // response data : reflection_id, reflection_name, date, status
 // 팀의 리더가 팀의 현재 회고에 디테일 정보(이름, 일시)를 추가한다.
 const updateReflectionDetail = async (req, res, next) => {
-    // TODO: 유저가 현재 팀의 리더인지 검증(미들웨어)
-    // TODO: 회고의 status가 회고 정보를 추가할 수 있는 상태인지 검증(미들웨어)
+
     try {
         // console.log('회고 정보 추가하기');
         const { reflection_id } = req.params;
         const { reflection_name, reflection_date } = req.body;
+
+        // 회고 일정 검증 (현 시간보다 이전이면 에러 반환)
+        const curDate = new Date();
+        const reflectionDate = new Date(reflection_date);
+        if (reflectionDate <= curDate) throw Error('회고 시간이 현 시간 이전');
 
         // 피드백 상세 정보 추가
         const updateReflectionSuccess = await reflection.update({
@@ -73,7 +77,6 @@ const updateReflectionDetail = async (req, res, next) => {
         });
 
         if (updateReflectionSuccess[0] === 0) throw Error('일치하는 회고 정보를 찾지 못함');
-
         const reflectionDetail = await reflection.findByPk(reflection_id);
 
         res.status(200).json({
@@ -120,7 +123,6 @@ const getPastReflectionList = async (req, res, next) => {
         });
     }
 }
-
 
 //* request data: reflection_id, team_id
 //* response data: id, reflection_name, date, state, team_id
@@ -169,9 +171,7 @@ const endInProgressReflection = async (req, res, next) => {
             message: error.message
         })
     }
-    
 }
-
 
 module.exports = {
     getCurrentReflectionDetail,


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재는 회고 일정 추가 시 현 시간보다 시간이 이전이어도 정상적으로 일정 추가 api가 수행됩니다.
현 시간 보다 이후의 일정만 추가할 수 있기 때문에 입력 받은 회고 일정을 검증하는 로직을 추가합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회고 일정이 존재하지 않을 경우에만 updateReflectionDetail api를 수행할 수 있습니다. 따라서 기존에 적용되어 있었던 reflectionTimeCheck 미들웨어를 수행하지 않도록 합니다.
- 데이터베이스에 저장된 시간을 가져올 때 string 값으로 가져오도록 설정해두었습니다. 따라서 string을 Date 형으로 변환하여 현 시간 new Date() 와 비교합니다.
- 회고 일정이 현 시간보다 이를 경우 에러를 반환합니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
updateReflectionDetail 실행.
reflection_date에 현 시간보다 이전 값 입력.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="637" alt="image" src="https://user-images.githubusercontent.com/67336936/203348543-fe1da86c-52cd-444c-97fe-ce4e4e74521b.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #67 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
