### PR TITLE
[FIX] reflectionStateCheck 배열 인자 받아서 실행하도록 수정

### DIFF
--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -120,7 +120,7 @@ const reflectionTimeCheck = async (req, res, next) => {
     }
 }
 
-const reflectionStateCheck = (requiredStateFirst, requiredStateSecond) => {
+const reflectionStateCheck = (...requiredStates) => {
     return async (req, res, next) => {
         try {
             // console.log('회고의 상태 검증');
@@ -150,13 +150,14 @@ const reflectionStateCheck = (requiredStateFirst, requiredStateSecond) => {
                 raw: true
             });
 
-            // 목표 상태가 한 개일 때, 두 개일 때 나눠서 처리
-            if (requiredStateSecond === undefined){
-                if (reflectionState.state !== requiredStateFirst) throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`);
-            } else {
-                if (reflectionState.state !== requiredStateFirst && reflectionState.state !== requiredStateSecond) throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`);
+            // parameter로 온 모든 상태에 대해 검증 (상태 일치한다면 다음 핸들러 진행, 모두 일치하지 않는다면 에러 반환)
+            for (const state of requiredStates) {
+                if (reflectionState.state === state) {
+                    next();
+                    return;
+                }
             }
-            next();
+            throw Error(`현재 회고의 상태 ${reflectionState.state}에 요청을 수행할 수 없음`)
 
         } catch (error) {
             res.status(400).json({

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -146,7 +146,6 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
         const { reflection_id, team_id } = req.params;
         const { members } = req.query;
         const user_id = req.user_id;
-
         // 팀이 진행 중인 현재 회고 id 가져오기
         if (reflection_id !== 'current') throw Error('잘못된 요청 URI');
         const currentReflectionId = await team.findByPk(team_id, {

--- a/Maddori.Apple-Server/routes/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/feedbacks/index.js
@@ -28,7 +28,7 @@ router.post('/', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeChec
 router.get('/', [userTeamCheck, teamReflectionRelationCheck, reflectionStateCheck('Done')], getCertainTypeFeedbackAll);
 router.put('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck, validateFeedback], updateFeedback);
 router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck], deleteFeedback);
-router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before')], getFromMeToCertainMemberFeedbackAll);
+router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before', 'Progressing')], getFromMeToCertainMemberFeedbackAll);
 router.get('/from-team', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], getTeamAndUserFeedback);
 
 module.exports = router;


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
기존에는 reflectionStateCheck에서 최대 두 개까지의 상태만 받아서, 회고가 해당 상태를 만족하는지 검증했습니다.
하지만 getFromMeToCertainMemberFeedbackAll에서 3개 중 하나의 상태에 만족하는지를 판단해야 하기 때문에 reflectionStateCheck 미들웨어를 수정합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
reflectionStateCheck에서 배열 인자를 받는 형식으로 수정합니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
getFromMeToCertainMemberFeedbackAll 수행.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #78 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
