### PR TITLE
[ADD] getCurrentReflectionDetail 키워드 리스트 역순 설정 추가(#48)

### DIFF
--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -23,6 +23,9 @@ async function getCurrentReflectionDetail(req, res, next) {
             where: {
                 reflection_id: currentReflectionId.current_reflection_id
             },
+            order: [
+                ['id', 'DESC']
+            ],
             raw : true
         });
         


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
홈 화면에서 키워드 리스트를 역순으로 받아와야 합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
키워드 리스트를 불러오는 과정에서 order 설정을 추가하였습니다.
id 기준으로 내림차순 나열하였으며, timestamp 필드가 없기 때문에 id를 정렬의 기준으로 사용하였습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
getCurrentReflectionDetail 실행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="427" alt="image" src="https://user-images.githubusercontent.com/67336936/203928033-b1f9e25e-90e8-44eb-a8e8-70110bfc0e82.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
추후 timestamp 를 추가하여 timestamp 기준으로 정렬하는 것이 좋을 것 같습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
