### PR TITLE
[FEAT] 회원 탈퇴 api 구현

### DIFF
--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -123,6 +123,36 @@ const appleLogin = async (req, res, next) => {
     }
 }
 
+const signOut = async (req, res, next) => {
+    // console.log('회원 탈퇴 시작');
+    try {
+        const user_id = req.user_id;
+
+        // 유저 정보 삭제하기
+        const deletedUser = await user.destroy({
+            where: {
+                id: user_id
+            }
+        });
+        // 삭제할 유저 정보가 없을 경우 에러 반환
+        if (!deletedUser) throw Error('삭제할 유저 정보가 없습니다');
+
+        return res.status(200).json({
+            'success': true,
+            'message': '유저 정보 삭제 성공'
+        })
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '유저 정보 삭제 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
-    appleLogin
+    appleLogin,
+    signOut
 }

--- a/Maddori.Apple-Server/routes/auth/index.js
+++ b/Maddori.Apple-Server/routes/auth/index.js
@@ -2,9 +2,15 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
 const {
-    appleLogin
+    userCheck,
+} = require('../../middlewares/auth');
+
+const {
+    appleLogin,
+    signOut
 } = require('./auth');
 
 router.post('/', appleLogin);
+router.delete('/signout', [userCheck], signOut);
 
 module.exports = router;


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
회원 탈퇴 기능이 필요해짐으로써 회원 정보 삭제를 진행하는 회원 탈퇴 api 구현

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회원 탈퇴 api 구현
  token을 활용한 유저 정보 파악 이후 user 테이블에서 해당 user의 정보 삭제하기
- 회원의 정보(username, email, refresh_token), 회원과 관련된 정보(팀과의 관계, 받았던 피드백) 삭제 확인

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- singOut api 실행 (delete /api/v1/login/signout)

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- 유저 정보 삭제 성공
<img width="716" alt="image" src="https://user-images.githubusercontent.com/67336936/204205769-d07733a7-2c0a-4b5f-9abf-c4566105bd03.png">
- 유저 정보 삭제 실패
<img width="605" alt="image" src="https://user-images.githubusercontent.com/67336936/204205796-050daaa2-6410-4f6a-aa6a-ba7386a6d082.png">

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
/login/signout 이라는 URI가 어색해서, 추후에 /signout으로 바꿔야 할 것 같습니다.
현재는 auth 로 login, signout을 함께 묶느라 /login/signout 형태로 URI 설계하였습니다.
ASAP이기 때문에 코드 리뷰 없이 머지합니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #87 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
