### PR TITLE
[CHORE] API URI 변경 

### DIFF
--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -21,7 +21,7 @@ app.get('/', (req, res) => {
   res.send('Hello World! This is KeyGo server')
 });
 
-app.use('/api/v1/login', require('./routes/auth/index'));
+app.use('/api/v1/auth', require('./routes/auth/index'));
 
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
 app.use('/api/v1/users', require('./routes/users/index'));

--- a/Maddori.Apple-Server/routes/auth/index.js
+++ b/Maddori.Apple-Server/routes/auth/index.js
@@ -11,6 +11,6 @@ const {
 } = require('./auth');
 
 router.post('/', appleLogin);
-router.delete('/signout', [userCheck], signOut);
+router.delete('/signOut', [userCheck], signOut);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -358,7 +358,7 @@ const getTeamAndUserFeedback = async (req, res) => {
 
     let category = 'self';
     
-    if (user_id !== member_id) { 
+    if (user_id.toString() !== member_id.toString()) { 
        category = 'others';
     }
     

--- a/Maddori.Apple-Server/routes/users/index.js
+++ b/Maddori.Apple-Server/routes/users/index.js
@@ -18,7 +18,7 @@ const {
 // user auth 검증
 router.use('/', userCheck);
 // handler
-router.post('/login', [validateUsername], userLogin);
+router.post('/nickName', [validateUsername], userLogin);
 router.post('/join-team/:team_id', userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- API URI를 설계 조정했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 기존의 애플 로그인 uri가 /login 으로 시작되었는데, 의미상 user api와 분리하기 위하여, auth로 변경했습니다.
- 닉네임 설정하는 api를 리소스 관점에서 users/nickName 으로 변경하였습니다.
- 유저 삭제 API를 signOut으로 변경하였습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 삭제 API에서 URI 변경하면서, SignOut api code를 살펴보았는데, 현재는 destroy로 회원을 완전 삭제하는데, 서비스를 운영하면 soft delete로 전환해야하는 것인가? 라는 고민이 들었습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #94 

