### PR TITLE
[FEAT] reflection 일정 현재(분 단위)로 등록할 수 있도록 수정

### DIFF
--- a/Maddori.Apple-Server/middlewares/auth.js
+++ b/Maddori.Apple-Server/middlewares/auth.js
@@ -104,7 +104,7 @@ const reflectionTimeCheck = async (req, res, next) => {
             where: {
                 id: reflection_id,
                 team_id: team_id,
-                date: { [Op.lt]: new Date() },
+                date: { [Op.lte]: new Date() },
                 state: { [Op.ne]: 'Done'}
             },
             raw: true

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -66,10 +66,12 @@ const updateReflectionDetail = async (req, res, next) => {
         const { reflection_name, reflection_date } = req.body;
 
         // 회고 일정 검증 (현 시간보다 이전이면 에러 반환)
-        const curDate = new Date();
+        const curDateWithSecond = new Date();
+        const curDate = new Date(curDateWithSecond.setSeconds(0, 0));
         const reflectionDate = new Date(reflection_date);
-        if (reflectionDate <= curDate) throw Error('회고 시간이 현 시간 이전');
-
+        console.log(curDate);
+        console.log(reflectionDate);
+        if (reflectionDate < curDate) throw Error('회고 시간이 현 시간 이전');
         // 피드백 상세 정보 추가
         const updateReflectionSuccess = await reflection.update({
             reflection_name: reflection_name,

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -69,8 +69,7 @@ const updateReflectionDetail = async (req, res, next) => {
         const curDateWithSecond = new Date();
         const curDate = new Date(curDateWithSecond.setSeconds(0, 0));
         const reflectionDate = new Date(reflection_date);
-        console.log(curDate);
-        console.log(reflectionDate);
+
         if (reflectionDate < curDate) throw Error('회고 시간이 현 시간 이전');
         // 피드백 상세 정보 추가
         const updateReflectionSuccess = await reflection.update({


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
쇼케이스 부스 진행시 회고를 바로 진행할 수 있게 일정을 현재로(분까지 일치하는 시간) 등록할 수 있어야합니다. (클라이언트에서는 초를 지정할 수 없기 때문에 항상 ??시 ??분 으로 등록 시간 값이 들어옵니다)
또한 회고를 바로 시작하고 싶을 때 일정을 현재로 등록해야하기 때문에 위 기능을 추가합니다.

- 기존 구현 방법
  기존에는 `등록시간<현재시간(초 포함)` 일 때만 회고 일정 등록이 가능하도록 해주었기 때문에 등록시간이 13:00일 경우 현재 시간이 13:00:01 초라면 회고 일정이 등록되지 못합니다. 따라서 회고를 바로 시작하고 싶다면 항상 1분 뒤로 회고 일정을 등록해야 합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 회고 일정 등록(updateReflectionDetail) api 수정
   현재 시간에서 초 단위를 제거하고 요청으로 들어오는 회고 일정 시간 값과 비교를 진행합니다.
   회고 일정 요청 값 < 현재 시간 값 (분 단위) 를 만족한다면 회고 일정이 성공적으로 등록될 것입니다.
- 회고 시간 검증(reflectionTimeCheck) api 수정
   현재 시간과 회고 일정이 동일할 때도 회고 상태가 바뀌도록 수정

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
updateReflectionDetail api 수행
- 현재 시간과 동일하게 회고 일정을 등록하면, 메인 화면에서 다시 getCurrentReflectionDetail이 수행되며 reflectionTimeCheck 미들웨어가 수행되어 회고 상태가 Progressing으로 바뀌게 됩니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
현재 시간으로 지정해도 회고 일정이 정상적으로 등록되는 결과
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/67336936/206828791-a5dfb813-8abe-4b32-b5c7-b41f681c4e4e.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #97 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
