### PR TITLE
[CHORE] API 상수로 관리

### DIFF
--- a/Maddori.Apple-Server/.idea/.gitignore
+++ b/Maddori.Apple-Server/.idea/.gitignore
@@ -1,5 +1,0 @@
-# 디폴트 무시된 파일
-/shelf/
-/workspace.xml
-# 에디터 기반 HTTP 클라이언트 요청
-/httpRequests/

--- a/Maddori.Apple-Server/app.js
+++ b/Maddori.Apple-Server/app.js
@@ -21,7 +21,7 @@ app.get('/', (req, res) => {
   res.send('Hello World! This is KeyGo server')
 });
 
-app.use('/api/v1/login', require('./routes/auth/index'));
+app.use('/api/v1/auth', require('./routes/auth/index'));
 
 // 라우팅 (users, teams, reflections, feedbacks 로 분리)
 app.use('/api/v1/users', require('./routes/users/index'));

--- a/Maddori.Apple-Server/constants/response.js
+++ b/Maddori.Apple-Server/constants/response.js
@@ -1,0 +1,17 @@
+module.exports = {
+    success: (status, message, detail) => {
+        return {
+            status,
+            success: true,
+            message,
+            detail,
+        };
+    },
+    fail: (status, message) => {
+        return {
+            status,
+            success: false,
+            message,
+        };
+    },
+};

--- a/Maddori.Apple-Server/constants/responseMessage.js
+++ b/Maddori.Apple-Server/constants/responseMessage.js
@@ -1,0 +1,78 @@
+module.exports = {
+    OK: "성공",
+    BAD_REQUEST: "요청을 잘못 보냈습니다.",
+    PAGE_NOT_FOUND: "요청하신 페이지를 찾을 수 없습니다",
+    NEED_LOGIN: "로그인이 필요합니다.",
+    NO_CONTENT: "데이터가 없습니다.",
+    REPEATED_VALUE: "중복된 데이터입니다.",
+    UNAUTHORIZED: "권한이 없습니다",
+    INTERNAL_SERVER_ERROR: "서버 내부 오류",
+    PASSWORD_NOT_VALID: "비밀번호를 형식이 잘못 되었습니다.",
+
+    // JWT 관련
+    NO_TOKEN: "TOKEN이 존재하지 않습니다.",
+    TOKEN_INVALID: "TOKEN이 유효하지 않습니다.",
+    TOKEN_EXPIRED: "TOKEN이 만료되었습니다.",
+
+    // 로그인, 회원가입 관련
+    NOT_FOUND: "",
+    INVALID_PASSWORD: "패스워드가 유효하지 않습니다.",
+    SIGN_IN_SUCCESS: "로그인 성공",
+    SIGN_IN_FAIL: "로그아웃 실패",
+    SIGN_UP_SUCCESS: "회원가입 성공",
+    SIGN_UP_FAIL: "회원가입 실패",
+    USER_EXIST: "존재하는 회원입니다.",
+
+    // 유저 관련
+    SET_USER_NICKNAME_SUCCESS: '유저 닉네임 설정 성공',
+    SET_USER_NICKNAME_FAIL: '유저 닉네임 설정 실패',
+    DELETE_USER_SUCCESS: '유저 정보 삭제 성공',
+    DELETE_USER_FAIL: '유저 정보 삭제 실패',
+    
+    // 회고 관련
+    GET_REFLECTION_SUCCESS: '현재 회고 정보 가져오기 성공',
+    GET_REFLECTION_FAIL: '현재 회고 정보 가져오기 실패',
+
+    UPDATE_REFLECTION_DETAIL_SUCCESS: '회고 디테일 정보 추가 성공',
+    UPDATE_REFLECTION_DETAIL_FAIL: '회고 디테일 정보 추가 실패',
+    
+    GET_REFLECTION_LIST_SUCCESS: '회고목록 조회 성공',
+    GET_REFLECTION_LIST_FAIL: '회고목록 조회 실패',
+
+    END_REFLECTION_SUCCESS: '회고 종료 성공',
+
+    // 팀 관련
+    INVALID_INVITATION_CODE: '초대코드가 잘못 됨',
+    GET_TEAM_INFO_SUCCESS: '팀 정보 가져오기 성공',
+    GET_TEAM_INFO_FAIL: '팀 정보 가져오기 실패',
+    WITHDRAW_TEAM_SUCCESS: '유저 팀 탈퇴 성공',
+    WITHDRAW_TEAM_FAIL: '유저 팀 탈퇴 실패',
+    GET_TEAM_MEMBER_LIST_SUCCESS: '팀의 멤버 목록 가져오기 성공',
+    GET_TEAM_MEMBER_LIST_FAIL: '팀의 멤버 목록 가져오기 실패',
+
+    CREATE_TEAM_SUCCESS_APPOINT_TEAM_LEADER: '팀 생성 완료, 유저를 해당 팀의 리더로 설정',
+    CREATE_TEAM_FAIL: '팀 생성 실패',
+    JOIN_TEAM_SUCCESS: '유저 팀 합류 성공',
+    JOIN_TEAM_FAIL: '유저 팀 합류 실패',
+    NOT_INCLUDED_USER: '피드백을 받는 유저가 현재 팀에 속하지 않음',
+
+    // 피드백 관련
+    CREATE_FEEDBACK_SUCCESS: '피드백 생성하기 성공',
+    CREATE_FEEDBACK_FAIL: '피드백 생성하기 실패',
+    GET_FEEDBACK_SUCCESS: '피드백 조회 성공',
+    GET_FEEDBACK_FAIL: '피드백 조회 실패',
+    GET_RECENT_FEEDBACK_SUCCESS: '최근 피드백 조회 성공',
+    GET_RECENT_FEEDBACK_FAIL: '최근 피드백 조회 실패',
+    FEEDBACK_TYPE_ERROR: '피드백 타입 오류',
+    GET_FEEDBACK_LIST_TO_SPECIFIC_MEMBER_SUCCESS: '특정 유저에게 작성한 피드백 목록 가져오기 성공',
+    GET_FEEDBACK_LIST_TO_SPECIFIC_MEMBER_FAIL: '특정 유저에게 작성한 피드백 목록 가져오기 실패',
+    DELETE_FEEDBACK_SUCCESS: '피드백 삭제 성공',
+    DELETE_FEEDBACK_FAIL: '피드백 삭제 실패',
+    UPDATE_FEEDBACK_SUCCESS: '피드백 수정 성공',
+    UPDATE_FEEDBACK_FAIL: '피드백 수정 실패',
+
+
+
+}
+
+

--- a/Maddori.Apple-Server/constants/statusCode.js
+++ b/Maddori.Apple-Server/constants/statusCode.js
@@ -1,0 +1,13 @@
+가module.exports = {
+    OK: 200,
+    CREATED: 201,
+    NO_CONTENT: 204,
+    BAD_REQUEST: 400,
+    UNAUTHORIZED: 401,
+    FORBIDDEN: 403,
+    NOT_FOUND: 404,
+    CONFLICT: 409,
+    INTERNAL_SERVER_ERROR: 500,
+    SERVICE_UNAVAILABLE: 503,
+    DB_ERROR: 600,
+  };

--- a/Maddori.Apple-Server/routes/auth/auth.js
+++ b/Maddori.Apple-Server/routes/auth/auth.js
@@ -1,11 +1,14 @@
 const {user, team, userteam, reflection, feedback, usertoken } = require('../../models');
 const jwtUtil = require('../../utils/jwt.util');
 const jwt = require('jsonwebtoken');
+const sc = require('../../constants/statusCode');
+const m = require('../../constants/responseMessage');
+const { success, fail } = require('../../constants/response');
 
 // request data: identity token
 // response data: access_token, refresh_token, user 정보
 // apple social login을 진행하고, 토큰을 발급한다.
-const appleLogin = async (req, res, next) => {
+const appleLogin = async (req, res) => {
     const { token } = req.body;
 
     try {
@@ -14,10 +17,10 @@ const appleLogin = async (req, res, next) => {
         await jwtUtil.generateKey(token).then((result) => {
             if (result.type === false) {
                 // public key 생성 오류는 서버 에러로 처리
-                return res.status(500).json({
+                return res.status(sc.INTERNAL_SERVER_ERROR).json({
                     success: false,
-                    message: '유저 로그인 실패',
-                    detail: '서버 오류'
+                    message: m.SIGN_IN_FAIL,
+                    detail: m.INTERNAL_SERVER_ERROR
                 })
             }
             publicKeyPem = result.key;
@@ -75,9 +78,9 @@ const appleLogin = async (req, res, next) => {
                 }
             });
 
-            return res.status(200).json({
+            return res.status(sc.OK).json({
                 success: true,
-                message: '유저 로그인 성공',
+                message: m.SIGN_IN_SUCCESS,
                 detail: {
                     created: false,
                     access_token: accessToken,
@@ -97,9 +100,9 @@ const appleLogin = async (req, res, next) => {
                 refresh_token: refreshToken
             });
 
-            return res.status(200).json({
+            return res.status(sc.OK).json({
                 success: true,
-                message: '유저 회원가입과 로그인 성공',
+                message: m.SIGN_UP_SUCCESS,
                 detail: {
                     created: true,
                     access_token: accessToken,
@@ -115,9 +118,9 @@ const appleLogin = async (req, res, next) => {
 
     } catch (error) {
         // TODO: 에러 처리 수정
-        res.status(400).json({
+        res.status(sc.BAD_REQUEST).json({
             success: false,
-            message: '유저 로그인 실패',
+            message: m.SIGN_IN_FAIL,
             detail: error.message
         });
     }
@@ -137,16 +140,16 @@ const signOut = async (req, res, next) => {
         // 삭제할 유저 정보가 없을 경우 에러 반환
         if (!deletedUser) throw Error('삭제할 유저 정보가 없습니다');
 
-        return res.status(200).json({
+        return res.status(sc.OK).json({
             'success': true,
-            'message': '유저 정보 삭제 성공'
+            'message': m.DELETE_USER_SUCCESS
         })
 
     } catch (error) {
         // TODO: 에러 처리 수정
-        res.status(400).json({
+        res.status(sc.BAD_REQUEST).json({
             success: false,
-            message: '유저 정보 삭제 실패',
+            message: m.DELETE_USER_FAIL,
             detail: error.message
         });
     }

--- a/Maddori.Apple-Server/routes/auth/index.js
+++ b/Maddori.Apple-Server/routes/auth/index.js
@@ -11,6 +11,6 @@ const {
 } = require('./auth');
 
 router.post('/', appleLogin);
-router.delete('/signout', [userCheck], signOut);
+router.delete('/signOut', [userCheck], signOut);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -1,10 +1,13 @@
 const {user, team, userteam, reflection, feedback } = require('../../models');
 const { Op } = require("sequelize");
+const sc = require('../../constants/statusCode');
+const m = require('../../constants/responseMessage');
+const { success, fail } = require('../../constants/response');
 
 // request data : user_id, team_id, reflection_id, feedback information(type, keyword, content, to_id, start_content)
 // response data : feedback information(type, keyword, content, from_id, to_id, is_favorite, start_content)
 // 회고에 새로운 피드백을 등록한다 
-async function createFeedback(req, res, next) {
+const createFeedback = async (req, res) => {
     // console.log("피드백 생성하기");
     const feedbackContent = req.body;
     
@@ -28,10 +31,7 @@ async function createFeedback(req, res, next) {
 
         // type 검증
         if (!(type === 'Continue' || type === 'Stop')) {
-            return res.status(400).json({
-                'success': false,
-                'message': '피드백의 타입정보 오류'
-            });
+            return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST,m.FEEDBACK_TYPE_ERROR))
         }
 
         // 피드백 등록
@@ -45,21 +45,13 @@ async function createFeedback(req, res, next) {
             team_id: parseInt(team_id),
             reflection_id: parseInt(reflection_id)
         });
+        res.status(sc.CREATED).send(success(sc.CREATED, m.CREATE_FEEDBACK_SUCCESS, createdFeedback));
 
-        res.status(201).json({
-            success: true,
-            message: '피드백 생성하기 성공',
-            detail: createdFeedback
-        });
     } catch (error) {
-        // TODO: 에러 처리 수정
-        res.status(400).json({
-            success: false,
-            message: '피드백 생성하기 실패',
-            detail: error.message
-        });
+        res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.CREATE_FEEDBACK_FAIL));
     }
 }
+
 
 // request data: team_id, reflection_id, type
 // response data: id, type, keyword, content, start_content, from_id, to_id, 
@@ -95,13 +87,7 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
                     }
                 ]
             }) 
-            return res.status(200).json({
-                'success': true,
-                'message': '최근 회고 피드백 조회 성공',
-                'detail': {
-                    'feedback': feedbackData
-                }
-            });         
+            return res.status(sc.OK).send(success(sc.OK, m.GET_RECENT_FEEDBACK_SUCCESS, {'feedback': feedbackData}));
         }
         const feedbackData = await feedback.findAll({
             where: {
@@ -121,19 +107,9 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
                 }
             ]
         })
-        return res.status(200).json({
-            'success': true,
-            'message': '피드백 정보 조회 성공',
-            'detail': {
-                'feedback': feedbackData
-            }
-        });
+        return res.status(sc.OK).send(success(sc.OK, m.CREATE_FEEDBACK_SUCCESS, {'feedback':feedbackData}));
     } catch (error) {
-        return res.status(400).json({
-            'success': false,
-            'message': '피드백 정보 조회 실패',
-            'detail': error.message
-        })
+        return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.GET_FEEDBACK_FAIL));
     }
 }
 
@@ -168,7 +144,7 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
             },
             raw: true
         });
-        if (!membersDetail) throw Error('피드백을 받는 유저가 현재 팀에 속하지 않음');
+        if (!membersDetail) throw Error(m.NOT_INCLUDED_USER);
 
         // 현재 회고의 피드백 중 유저가 특정 멤버에게 작성한 피드백 정보 가져오기
         const feedbacksToCertainMember = await feedback.findAll({
@@ -197,20 +173,11 @@ const getFromMeToCertainMemberFeedbackAll = async (req, res) => {
             const { type, ...contents } = data;
             feedbacksToCertainMemberGroupByType[type].push(contents);
         });
-
-        res.status(200).json({
-            success: true,
-            message: '특정 멤버에게 작성한 피드백 목록 가져오기 성공',
-            detail: feedbacksToCertainMemberGroupByType
-        });
+        res.status(sc.OK).send(success(sc.OK, m.GET_FEEDBACK_LIST_TO_SPECIFIC_MEMBER_SUCCESS, feedbacksToCertainMemberGroupByType));
 
     } catch (error) {
         // TODO: 에러 처리 수정
-        res.status(400).json({
-            success: false,
-            message: '특정 멤버에게 작성한 피드백 목록 가져오기 실패',
-            detail: error.message
-        });
+        res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.GET_FEEDBACK_LIST_TO_SPECIFIC_MEMBER_FAIL));
     }
 }
 
@@ -230,7 +197,7 @@ const updateFeedback = async (req, res, next) => {
 
         // 피드백 타입 오류에 대한 에러 반환
         if (!(type === 'Continue' || type === 'Stop')) {
-            return res.status(400).json({
+            return res.status(sc.BAD_REQUEST).json({
                 'success': false,
                 'message': '피드백의 타입정보 오류'
             })
@@ -259,19 +226,9 @@ const updateFeedback = async (req, res, next) => {
                     as: 'to_user'
                 }]
         });
-
-        return res.status(200).json({
-            'success': true,
-            'message': '피드백 정보 수정 성공',
-            'detail': {
-                'feedback': resultFeedbackData
-            }});
+        return res.status(sc.OK).send(success(sc.OK, m.UPDATE_FEEDBACK_SUCCESS, {'feedback':resultFeedbackData}))
         } catch (error) {
-            return res.status(400).json({
-                'success': false,
-                'message': '피드백 정보 수정 실패',
-                'detail': error.message
-            });
+            return res.status(sc.BAD_REQUEST).send(sc.BAD_REQUEST, m.UPDATE_FEEDBACK_FAIL);
         }
     
 }
@@ -295,22 +252,13 @@ const deleteFeedback = async (req, res, next) => {
         });
 
         if (!feedbackData) {
-            return res.status(400).json({
-                'success': false,
-                'message': '삭제할 피드백 정보가 없습니다.'
-            })
+            return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.DELETE_FEEDBACK_FAIL));
         }
+        res.status(sc.OK).send(success(sc.OK, m.DELETE_FEEDBACK_SUCCESS));
 
-        return res.status(200).json({
-            'success': true,
-            'message': '피드백 정보 삭제 성공'
-        })
     } catch (error) {
-        return res.status(400).json({
-            'success': false,
-            'message': '피드백 정보 삭제 실패',
-            'detail': error.message
-        })
+        console.log(error)
+        res.status(sc.BAD_REQUEST).send(sc.BAD_REQUEST, m.DELETE_FEEDBACK_FAIL);
     }
 }
 
@@ -361,22 +309,18 @@ const getTeamAndUserFeedback = async (req, res) => {
     if (user_id.toString() !== member_id.toString()) { 
        category = 'others';
     }
-    
-    return res.status(200).json({
-        success: true,
-        message: "피드백 조회 성공",
-        detail: {
-            category: category,
-            user_feedback: userFeedbackData,
-            team_feedback: teamFeedbackData 
-        }
-    })
+
+    const responseData = {
+        category: category,
+        user_feedback: userFeedbackData,
+        team_feedback: teamFeedbackData
+    }
+
+    return res.status(sc.OK).send(success(sc.OK,m.OK, responseData));
+
     } catch (error) {
-        return res.status(400).json({
-            success: true,
-            message: "피드백 조회 실패",
-            detail: error.message
-        })
+        console.log(error);
+        return res.status(sc.BAD_REQUEST).send(sc.BAD_REQUEST, m.GET_FEEDBACK_FAIL);
     }
     
 };

--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -358,7 +358,7 @@ const getTeamAndUserFeedback = async (req, res) => {
 
     let category = 'self';
     
-    if (user_id !== member_id) { 
+    if (user_id.toString() !== member_id.toString()) { 
        category = 'others';
     }
     

--- a/Maddori.Apple-Server/routes/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/reflections/reflections.js
@@ -1,10 +1,12 @@
 const {user, team, reflection, feedback} = require('../../models');
+const sc = require('../../constants/statusCode');
+const m = require('../../constants/responseMessage');
+const { success, fail } = require('../../constants/response');
 
 // request data : user_id, team_id
 // response data : current_reflection_id, reflection_name, date, status, 회고에 속한 keywords 목록
 // 팀에서 진행하는 현재의 회고 정보 가져오기
-async function getCurrentReflectionDetail(req, res, next) {
-    // console.log("현재 회고 정보 가져오기");
+const getCurrentReflectionDetail = async (req, res) => {
 
     try {
         const user_id = req.user_id;
@@ -37,20 +39,12 @@ async function getCurrentReflectionDetail(req, res, next) {
             reflection_status: reflectionInformation.state,
             reflection_keywords: keywordsList.map((data) => data.keyword)
         }
+        res.status(sc.OK).send(success(sc.OK, m.GET_REFLECTION_SUCCESS, reflectionFinalInformation));
 
-        res.status(200).json({
-            success: true,
-            message: '현재 회고 정보 가져오기 성공',
-            detail: reflectionFinalInformation
-        });
 
     } catch (error) {
-        // TODO: 에러 처리 수정
-        res.status(400).json({
-            success: false,
-            message: '현재 회고 정보 가져오기 실패',
-            detail: error.message
-        });
+        console.log(error);
+        res.status(sc.BAD_REQUEST).send(sc.BAD_REQUEST, m.GET_REFLECTION_FAIL);
     }
 }
 
@@ -83,20 +77,11 @@ const updateReflectionDetail = async (req, res, next) => {
 
         if (updateReflectionSuccess[0] === 0) throw Error('일치하는 회고 정보를 찾지 못함');
         const reflectionDetail = await reflection.findByPk(reflection_id);
-
-        res.status(200).json({
-            success: true,
-            message: '회고 디테일 정보 추가 성공',
-            detail: reflectionDetail
-        });
+        res.status(sc.OK).send(success(sc.OK, m.UPDATE_REFLECTION_DETAIL_SUCCESS, reflectionDetail));
 
     } catch (error) {
-        // TODO: 에러 처리 수정
-        res.status(400).json({
-            success: false,
-            message: '회고 디테일 정보 추가 실패',
-            detail: error.message
-        });
+        console.log(error);
+        res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.UPDATE_REFLECTION_DETAIL_FAIL));
     }
 }
 
@@ -114,19 +99,16 @@ const getPastReflectionList = async (req, res, next) => {
                 state: "Done"
             }
         });
-        return res.status(200).json({
+        return res.status(sc.OK).json({
             "success": true,
-            "message": "data 조회 성공",
+            "message": m.GET_REFLECTION_LIST_SUCCESS,
             "detail": {
                 "reflection": [reflectionData]
             }
         });
     } catch (error) {
-        return res.status(400).json({
-            success: false,
-            message: "회고목록 조회 실패",
-            detail: error.message
-        });
+        console.log(error);
+        return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.GET_REFLECTION_LIST_FAIL));
     }
 }
 
@@ -169,19 +151,11 @@ const endInProgressReflection = async (req, res, next) => {
                 id: team_id
             }
         });
-        
-        return res.status(200).json({
-            success: true,
-            message: "회고 종료 성공",
-            detail: {
-                reflection: data
-            }
-        })
+        return res.status(sc.OK).send(sc.OK, m.END_REFLECTION_SUCCESS, {reflection: data});
+
     } catch (error) {
-        return res.status(400).json({
-            success: false,
-            message: error.message
-        })
+        console.log(error);
+        return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.UPDATE_FEEDBACK_FAIL));
     }
 }
 

--- a/Maddori.Apple-Server/routes/users/index.js
+++ b/Maddori.Apple-Server/routes/users/index.js
@@ -18,7 +18,7 @@ const {
 // user auth 검증
 router.use('/', userCheck);
 // handler
-router.post('/login', [validateUsername], userLogin);
+router.post('/nickName', [validateUsername], userLogin);
 router.post('/join-team/:team_id', userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
 

--- a/Maddori.Apple-Server/routes/users/users.js
+++ b/Maddori.Apple-Server/routes/users/users.js
@@ -1,10 +1,13 @@
 const {user, team, userteam, reflection, feedback} = require('../../models');
+const sc = require('../../constants/statusCode');
+const m = require('../../constants/responseMessage');
+const { success, fail } = require('../../constants/response');
 
 // TODO : social login, token 생성 방식으로 변경
 // request data : username
 // response data : user_id, username
 // 새로운 user 생성하기
-async function userLogin(req, res, next) {
+const userLogin = async (req, res) => {
     // console.log("유저 로그인");
     const user_id = req.user_id;
     const { username } = req.body;
@@ -18,9 +21,9 @@ async function userLogin(req, res, next) {
             }
         });
 
-        res.status(201).json({
+        res.status(sc.CREATED).json({
             success: true,
-            message: '유저 닉네임 설정 성공',
+            message: m.SET_USER_NICKNAME_SUCCESS,
             detail: {
                 username: username
             }
@@ -28,9 +31,9 @@ async function userLogin(req, res, next) {
 
     } catch (error) {
         // TODO: 에러 처리 수정
-        res.status(400).json({
+        res.status(sc.BAD_REQUEST).json({
             success: false,
-            message: '유저 닉네임 설정 실패',
+            message: m.SET_USER_NICKNAME_FAIL,
             detail: error.message
         });
     }
@@ -39,7 +42,7 @@ async function userLogin(req, res, next) {
 // request data : user_id, team_id
 // response data : userteam_id, user_id, team_id
 // 유저가 팀에 합류하기
-async function userJoinTeam(req, res, next) {
+const userJoinTeam = async (req, res) => {
     // console.log("유저 팀 조인");
     const user_id = req.user_id;
     const { team_id } = req.params;
@@ -62,26 +65,17 @@ async function userJoinTeam(req, res, next) {
         });
 
         if (created === false) throw Error('이미 유저가 해당 팀에 합류된 상태');
-        res.status(201).json({
-            success: true,
-            message: '유저 팀 합류 성공',
-            detail: createdUserteam
-        });
-
+        res.status(sc.CREATED).send(success(sc.CREATED, m.JOIN_TEAM_SUCCESS, createdUserteam));
     } catch (error) {
-        // TODO: 에러 처리 수정
-        res.status(400).json({
-            success: false,
-            message: '유저 팀 합류 실패',
-            detail: error.message
-        });
+        console.log(error);
+        res.status(sc.BAD_REQUEST).send(success(sc.BAD_REQUEST, m.JOIN_TEAM_FAIL));
     }
 }
 
 // request data : user_id, team_id
 // response data : 결과 처리 여부
 // 유저가 팀을 탈퇴하기
-async function userLeaveTeam(req, res, next) {
+const userLeaveTeam = async (req, res) => {
     
     try {
         const user_id = req.user_id;
@@ -94,24 +88,13 @@ async function userLeaveTeam(req, res, next) {
         });
         
         if (deletedUserTeam === 1) { // 삭제할 데이터 있음
-            res.status(200).json({
-                success: true,
-                message: '유저 팀 탈퇴 성공'
-            });
+            res.status(sc.OK).send(success(sc.OK, m.WITHDRAW_TEAM_SUCCESS));
         } else { // 삭제할 데이터 없음
-            res.status(400).json({
-                success: false,
-                message: '유저 팀 탈퇴 실패',
-                detail: '유저와 팀 정보가 잘못됨'
-            });
+            res.status(sc.OK).send(fail(sc.BAD_REQUEST, m.WITHDRAW_TEAM_FAIL));
         }
     } catch (error) {
-        // TODO: 에러 처리 수정
-        res.status(400).json({
-            success: false,
-            message: '유저 팀 탈퇴 실패',
-            detail: error.message
-        });
+        console.log(error)
+        res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, m.WITHDRAW_TEAM_FAIL));
     }
 }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 기존 코드에는 response message와 응답코드들이 전부 api에 직접 값으로 들어가 있었는데, 이를 상수로 만들어, 관리하기 위해 API를 작성.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
##### 1. 응답 메세지 포맷 변경
- 성공 
```
{
success: true,
message: ...,
detail: ...
}
```
```
{
status: ...
success: true,
message: ...,
detail: ...
}
```
- 실패
```
{
status: ...
success: false,
message: ...,
detail ...
}
```
```
{
status: ...
success: false,
message: ...,
}
```

- 실패시에 detail 부분을 바꿨는데, 이유는 기존의 detail 부분에 `error.message`를 담았는데, 이는 서버에서 관리해야할 error이기 때문에, 응답 메세지에 담을 필요가 없다고 판단했다. 따라서 error가 날 경우, `console.log`를 이용하여 error를 확인하고, 응답에는 메세지만 실어서 보내는 형태로 변경 했다.


##### 2. 상수화
가독성 및 코드 유지보수성을 위해서 아래 2가지를 상수로 만들어 `constants` 폴더에서 관리한다.
- response message
- status code

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- constants를 효율적으로 불러오는 module 관리법을 찾아보고 있다면, 이후에 refactoring하면 좋을 것 같다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #102 
