### PR TITLE
[CHORE] getTeamAndUserFeedback 받는 멤버가 현재 팀에 속하는지 검증하는 로직 추가

### DIFF
--- a/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/feedbacks/feedbacks.js
@@ -322,6 +322,15 @@ const getTeamAndUserFeedback = async (req, res) => {
         const member_id = req.query.members;
         const { team_id, reflection_id } = req.params
 
+        const memberTeam = await userteam.findOne({
+            where: {
+                user_id: member_id,
+                team_id: team_id
+            }
+        });
+
+        if (!memberTeam) throw Error('받는 멤버가 현재 팀에 속하지 않음');
+
         const userFeedbackData = await feedback.findAll({
             where: {
                 team_id: team_id,


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
getTeamAndUserFeedback에서 받는 사람이 팀에 존재하는지 검증이 필요합니다
- 기존에는 에러가 반환되지 않고 빈 데이터 값이 반환되었음
<img width="617" alt="image" src="https://user-images.githubusercontent.com/67336936/212027101-ad425a4f-f06c-40fa-bd63-06582af8e701.png">


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
피드백을 받는 멤버가 현재 팀에 속하는지 검증하는 로직 추가

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
아래 조건에 맞춰 getTeamAndUserFeedback api 실행
`?members=팀에 속하지 않는 유저의 id`

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
피드백을 받는 멤버가 현재 팀에 속해있지 않을 경우 응답 화면
<img width="617" alt="image" src="https://user-images.githubusercontent.com/67336936/212026591-b34fd72e-7d09-4328-a48c-3c61e6ffeaea.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
self와 other를 제대로 분리하지 못하는 부분은 이미 수정이 되어있어서 받는 멤버가 현재 팀에 속하는지 검증하는 로직 추가하는 작업만 수행했습니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #95 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
