### PR TITLE
[FEAT] 리더 관련 기능 삭제에 따른 API 버전 업데이트

### DIFF
--- a/Maddori.Apple-Server/routes/v1/users/users.js
+++ b/Maddori.Apple-Server/routes/v1/users/users.js
@@ -37,7 +37,7 @@ async function userLogin(req, res, next) {
 }
 
 // request data : user_id, team_id
-// response data : userteam_id, user_id, team_id
+// response data : userteam_id, user_id, team_id, admin
 // 유저가 팀에 합류하기
 async function userJoinTeam(req, res, next) {
     // console.log("유저 팀 조인");

--- a/Maddori.Apple-Server/routes/v2/index.js
+++ b/Maddori.Apple-Server/routes/v2/index.js
@@ -4,5 +4,6 @@ const router = new express.Router({ mergeParams: true });
 // 라우팅 (auth, users, teams, reflections, feedbacks 로 분리)
 router.use('/users', require('./users/index'));
 router.use('/teams', require('./teams/index'));
+router.use('/teams/:team_id/reflections', require('./reflections/index'));
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/index.js
+++ b/Maddori.Apple-Server/routes/v2/index.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
+// 라우팅 (auth, users, teams, reflections, feedbacks 로 분리)
 router.use('/users', require('./users/index'));
+router.use('/teams', require('./teams/index'));
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/index.js
+++ b/Maddori.Apple-Server/routes/v2/index.js
@@ -1,4 +1,6 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
+router.use('/users', require('./users/index'));
+
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/reflections/index.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/index.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = new express.Router({ mergeParams: true });
+const {
+    updateReflectionDetail
+} = require('./reflections');
+const {
+    userCheck,
+    userTeamCheck,
+    userAdminCheck,
+    reflectionTimeCheck,
+    reflectionStateCheck,
+    teamReflectionRelationCheck
+} = require('../../../middlewares/auth');
+const {
+    validateReflectionname
+} = require('../../../middlewares/validate');
+
+// user auth 검증
+router.use('/', userCheck);
+// handler
+// router.patch('/:reflection_id/end', [userTeamCheck, userAdminCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
+router.patch('/:reflection_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), validateReflectionname], updateReflectionDetail);
+
+module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/reflections/index.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/index.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 const {
-    updateReflectionDetail
+    updateReflectionDetail,
+    endInProgressReflection
 } = require('./reflections');
 const {
     userCheck,
@@ -18,7 +19,7 @@ const {
 // user auth 검증
 router.use('/', userCheck);
 // handler
-// router.patch('/:reflection_id/end', [userTeamCheck, userAdminCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
+router.patch('/:reflection_id/end', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
 router.patch('/:reflection_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), validateReflectionname], updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/reflections.js
@@ -1,0 +1,107 @@
+const {user, team, reflection, feedback} = require('../../../models');
+
+// request data : user_id, team_id, reflection_id, reflection_name, reflection_date
+// response data : reflection_id, reflection_name, date, status
+// 팀의 멤버가 팀의 현재 회고에 디테일 정보(이름, 일시)를 추가한다.
+const updateReflectionDetail = async (req, res, next) => {
+
+    try {
+        // console.log('회고 정보 추가하기');
+        const user_id = req.user_id;
+        const { reflection_id } = req.params;
+        const { reflection_name, reflection_date } = req.body;
+
+        // 회고 일정 검증 (현 시간보다 이전이면 에러 반환)
+        const curDateWithSecond = new Date();
+        const curDate = new Date(curDateWithSecond.setSeconds(0, 0));
+        const reflectionDate = new Date(reflection_date);
+
+        if (reflectionDate < curDate) throw Error('회고 시간이 현 시간 이전');
+        // 피드백 상세 정보 추가
+        const updateReflectionSuccess = await reflection.update({
+            reflection_name: reflection_name,
+            date: reflection_date,
+            state: 'Before'
+        }, {
+            where: {
+                id: reflection_id,
+            },
+        });
+
+        if (updateReflectionSuccess[0] === 0) throw Error('일치하는 회고 정보를 찾지 못함');
+        const reflectionDetail = await reflection.findByPk(reflection_id);
+
+        res.status(200).json({
+            success: true,
+            message: '회고 디테일 정보 추가 성공',
+            detail: reflectionDetail
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '회고 디테일 정보 추가 실패',
+            detail: error.message
+        });
+    }
+}
+
+//* request data: reflection_id, team_id
+//* response data: id, reflection_name, date, state, team_id
+//* 특정 회고를 종료하는 API
+// const endInProgressReflection = async (req, res, next) => {
+//     try {
+//         const user_id = req.user_id;
+//         const { reflection_id, team_id } = req.params;
+
+//         await reflection.update(
+//             {
+//                 state: "Done"
+//             },
+//             {
+//                 where:{
+//                     id: reflection_id,
+//                     team_id: team_id
+//                     }
+//             })
+//         const data = await reflection.findByPk(reflection_id);
+        
+//         // 새로운 회고 생성 및 team의 현재 회고 id 업데이트
+//         const newReflectionData = await reflection.create({
+//             team_id: team_id
+//         })
+//         await team.update({
+//             current_reflection_id: newReflectionData.id
+//         },{
+//             where: {
+//                 id: team_id
+//             }
+//         });
+//         // team의 최근 회고 id 업데이트
+//         await team.update({
+//             recent_reflection_id: reflection_id
+//         },{
+//             where: {
+//                 id: team_id
+//             }
+//         });
+        
+//         return res.status(200).json({
+//             success: true,
+//             message: "회고 종료 성공",
+//             detail: {
+//                 reflection: data
+//             }
+//         })
+//     } catch (error) {
+//         return res.status(400).json({
+//             success: false,
+//             message: error.message
+//         })
+//     }
+// }
+
+module.exports = {
+    updateReflectionDetail
+};

--- a/Maddori.Apple-Server/routes/v2/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/reflections.js
@@ -49,58 +49,59 @@ const updateReflectionDetail = async (req, res, next) => {
 //* request data: reflection_id, team_id
 //* response data: id, reflection_name, date, state, team_id
 //* 특정 회고를 종료하는 API
-// const endInProgressReflection = async (req, res, next) => {
-//     try {
-//         const user_id = req.user_id;
-//         const { reflection_id, team_id } = req.params;
+const endInProgressReflection = async (req, res, next) => {
+    try {
+        const user_id = req.user_id;
+        const { reflection_id, team_id } = req.params;
 
-//         await reflection.update(
-//             {
-//                 state: "Done"
-//             },
-//             {
-//                 where:{
-//                     id: reflection_id,
-//                     team_id: team_id
-//                     }
-//             })
-//         const data = await reflection.findByPk(reflection_id);
+        await reflection.update({
+            state: 'Done'
+        },{
+            where: {
+                id: reflection_id,
+                team_id: team_id,
+                state: 'Progressing'
+            }
+        });
+
+        const data = await reflection.findByPk(reflection_id);
         
-//         // 새로운 회고 생성 및 team의 현재 회고 id 업데이트
-//         const newReflectionData = await reflection.create({
-//             team_id: team_id
-//         })
-//         await team.update({
-//             current_reflection_id: newReflectionData.id
-//         },{
-//             where: {
-//                 id: team_id
-//             }
-//         });
-//         // team의 최근 회고 id 업데이트
-//         await team.update({
-//             recent_reflection_id: reflection_id
-//         },{
-//             where: {
-//                 id: team_id
-//             }
-//         });
+        // 새로운 회고 생성 및 team의 현재 회고 id 업데이트
+        const newReflectionData = await reflection.create({
+            team_id: team_id
+        })
+        await team.update({
+            current_reflection_id: newReflectionData.id
+        },{
+            where: {
+                id: team_id
+            }
+        });
+        // team의 최근 회고 id 업데이트
+        await team.update({
+            recent_reflection_id: reflection_id
+        },{
+            where: {
+                id: team_id
+            }
+        });
         
-//         return res.status(200).json({
-//             success: true,
-//             message: "회고 종료 성공",
-//             detail: {
-//                 reflection: data
-//             }
-//         })
-//     } catch (error) {
-//         return res.status(400).json({
-//             success: false,
-//             message: error.message
-//         })
-//     }
-// }
+        return res.status(200).json({
+            success: true,
+            message: "회고 종료 성공",
+            detail: {
+                reflection: data
+            }
+        })
+    } catch (error) {
+        return res.status(400).json({
+            success: false,
+            message: error.message
+        })
+    }
+}
 
 module.exports = {
-    updateReflectionDetail
+    updateReflectionDetail,
+    endInProgressReflection
 };

--- a/Maddori.Apple-Server/routes/v2/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/reflections.js
@@ -28,7 +28,6 @@ const updateReflectionDetail = async (req, res, next) => {
             },
         });
 
-        if (updateReflectionSuccess[0] === 0) throw Error('일치하는 회고 정보를 찾지 못함');
         const reflectionDetail = await reflection.findByPk(reflection_id);
 
         res.status(200).json({

--- a/Maddori.Apple-Server/routes/v2/teams/index.js
+++ b/Maddori.Apple-Server/routes/v2/teams/index.js
@@ -2,7 +2,8 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
 const {
-    createTeam
+    createTeam,
+    getCertainTeamDetail
 } = require('./teams');
 const {
     userCheck,
@@ -17,5 +18,6 @@ const {
 router.use('/', userCheck);
 // handler
 router.post('/', [validateTeamname], createTeam);
+router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/teams/index.js
+++ b/Maddori.Apple-Server/routes/v2/teams/index.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = new express.Router({ mergeParams: true });
+
+const {
+
+} = require('./teams');
+const {
+    userCheck,
+    userTeamCheck,
+    userAdminCheck
+} = require('../../../middlewares/auth');
+const {
+    validateTeamname
+} = require('../../../middlewares/validate');
+
+// user auth 검증
+router.use('/', userCheck);
+// handler
+
+module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/teams/index.js
+++ b/Maddori.Apple-Server/routes/v2/teams/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
 const {
-
+    createTeam
 } = require('./teams');
 const {
     userCheck,
@@ -16,5 +16,6 @@ const {
 // user auth 검증
 router.use('/', userCheck);
 // handler
+router.post('/', [validateTeamname], createTeam);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -1,0 +1,1 @@
+const {user, team, userteam, reflection, feedback} = require('../../../models');

--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -1,1 +1,91 @@
 const {user, team, userteam, reflection, feedback} = require('../../../models');
+
+// 팀 invitation_code 생성
+// reference : https://www.programiz.com/javascript/examples/generate-random-strings
+function generateCode() {
+    let generatedCode = '';
+    const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZ';
+    const codeLen = 6;
+    for (let i = 0; i < codeLen; i++) {
+        generatedCode += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return generatedCode;
+}
+
+// 팀 invitation_code 중복 여부 체크
+function checkDuplicateCode(createdTeamCode) {
+    const duplicateCode = team.findOne({
+        where: {
+            invitation_code: createdTeamCode
+        }
+    });
+    if (duplicateCode == null) {
+        // console.log("Code duplicate");
+        return true;
+    }
+    return false;
+}
+
+// request data : user_id, team_name
+// response data : team_id, team_name, team_code 
+// 유저가 팀 생성하기 (팀의 코드 생성, 팀의 첫번째 회고 자동 생성)
+async function createTeam(req, res, next) {
+    const user_id = req.user_id;
+    const teamContent = req.body;
+
+    try {
+        // 생성된 팀 코드가 중복되지 않을 때까지 반복
+        let createdTeamCode;
+        do {
+            createdTeamCode = generateCode();
+        } while (checkDuplicateCode(createdTeamCode));
+
+        // userteam 테이블에 저장할 유저의 이름 정보 찾기
+        const requestUser = await user.findByPk(user_id);
+
+        // 팀 생성
+        const createdTeam = await team.create({
+            team_name: teamContent.team_name,
+            invitation_code: createdTeamCode
+        });
+
+        // 팀 생성 후 첫 번째 회고 생성
+        const createdReflection = await reflection.create({
+            team_id: createdTeam.id
+        });
+
+        // 현재 팀의 current_reflection_id 업데이트
+        const updatedTeam = await team.update({
+            current_reflection_id: createdReflection.id
+        }, {
+            where: {
+                id: createdTeam.id
+            }
+        });
+
+        // 유저의 팀 합류
+        const createdUserTeam = await userteam.create({
+            user_id: user_id,
+            team_id: createdTeam.id,
+            nickname: requestUser.username
+        });
+        
+        res.status(201).json({
+            success: true,
+            message: '팀 생성 완료',
+            detail: createdTeam
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '팀 생성 실패',
+            detail: error.message
+        });
+    }
+}
+
+module.exports = {
+    createTeam
+}

--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -86,6 +86,38 @@ async function createTeam(req, res, next) {
     }
 }
 
+// request data : user_id, team_id
+// response data : team_id, team_name, invitation_code
+// 팀의 정보 가져오기
+async function getCertainTeamDetail(req, res, next) {
+    // console.log("팀의 정보 가져오기");
+
+    try {
+        const user_id = req.user_id;
+        const { team_id } = req.params;
+
+        // 팀의 team_id, team_name, invitation_code
+        const teamInformation = await team.findByPk(team_id, {
+            attributes: ['id', 'team_name', 'invitation_code']
+        });        
+
+        res.status(200).json({
+            success: true,
+            message: '유저가 속한 팀의 정보 가져오기 성공',
+            detail: teamInformation
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '유저가 속한 팀의 정보 가져오기 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
-    createTeam
+    createTeam,
+    getCertainTeamDetail
 }

--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = new express.Router({ mergeParams: true });
+const {
+    userJoinTeam
+} = require('./users');
+const {
+    userCheck,
+    userTeamCheck,
+    userAdminCheck,
+    reflectionStateCheck
+} = require('../../../middlewares/auth');
+const {
+    validateUsername
+} = require('../../../middlewares/validate');
+
+// user auth 검증
+router.use('/', userCheck);
+// handler
+router.post('/join-team/:team_id', userJoinTeam);
+
+module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -24,7 +24,7 @@ async function userJoinTeam(req, res, next) {
             },
             defaults: {
                 user_id: user_id,
-                team_id: team_id,
+                team_id: parseInt(team_id),
                 nickname: requestUser.username
             }
         });

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -1,0 +1,59 @@
+const {user, team, userteam, reflection, feedback} = require('../../../models');
+
+// request data : user_id, team_id
+// response data : userteam_id, user_id, team_id
+// 유저가 팀에 합류하기
+async function userJoinTeam(req, res, next) {
+    // console.log("유저 팀 조인");
+    const user_id = req.user_id;
+    const { team_id } = req.params;
+
+    try {
+        // team 정보 유효한지 체크
+        const requestTeam = await team.findByPk(team_id);
+        if (requestTeam === null) throw Error('요청하는 팀이 존재하지 않음');
+
+        // userteam 테이블에 저장할 유저의 이름 정보 찾기
+        const requestUser = await user.findByPk(user_id);
+
+        // userteam 테이블 업데이트
+        let [createdUserteam, created] = await userteam.findOrCreate({
+            where: {
+                user_id: user_id,
+                team_id: team_id
+            },
+            defaults: {
+                user_id: user_id,
+                team_id: team_id,
+                nickname: requestUser.username
+            }
+        });
+
+        if (created === false) throw Error('이미 유저가 해당 팀에 합류된 상태');
+        
+        // 프로필 관련 필드와 리더 정보 필드(v1.4 이후로 사용 안 함)는 반환하지 않음
+        createdUserteam = createdUserteam.dataValues;
+        delete createdUserteam.nickname;
+        delete createdUserteam.role;
+        delete createdUserteam.profile_picture;
+        delete createdUserteam.admin;
+        
+        res.status(201).json({
+            success: true,
+            message: '유저 팀 합류 성공',
+            detail: createdUserteam
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '유저 팀 합류 실패',
+            detail: error.message
+        });
+    }
+}
+
+module.exports = {
+    userJoinTeam
+};


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
리더 기능의 제거로 인해 기존 일부 api의 변경이 필요함.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
 - createTeam v2
   팀을 만든 유저의 리더 처리 진행하지 않도록 수정
 - userJoinTeam v2
   유저의 리더 정보는 반환하지 않도록 수정
   프로필 관련 정보 반환하지 않도록 구현
 - getCertainTeamDetail v2
   요청을 보내는 유저의 해당 팀 리더 여부 반환하지 않도록 수정
 - updateReflectionDetail v2
   Before 상태에서도 요청을 수행할 수 있도록 수정
   리더가 아니어도 요청을 수행할 수 있도록 수정
 - endInProgressReflection v2
   리더가 아니어도 요청을 수행할 수 있도록 수정

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
createTeam, userJoinTeam, getCertainTeamDetail, updateReflectionDetail, endInProgressReflection api 수행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- createTeam v2 Response
<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/214815099-990b53a0-54d7-4f7e-8b86-a0d325c6994c.png">

- userJoinTeam v2 Response
<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/214814925-faa30eb8-0021-48da-a70b-c991e64d3d56.png">

- getCertainTeamDetail v2 Response
<img width="400" alt="image" src="https://user-images.githubusercontent.com/67336936/214815185-24d1a1fc-a15d-469e-9232-f831245a0b43.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
api 구현 방법이 크게 달라지지 않는 상황에서 api 버전 분리를 진행하니 코드의 중복이 많이 발생합니다. api 버전 분리가 필요한건 확실한 것 같은데 이런 구현 방식이 올바른 방식인지 잘 모르겠네요..
다음부턴 각 세부 과정을 컴포넌트화 시켜서 해당 컴포넌트를 활용해 api를 구현하는게 좋을 것 같습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #113 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
