### PR TITLE
[ADD] api 버전 관리를 위한 기존 api의 version 2 URI 추가

### DIFF
--- a/Maddori.Apple-Server/routes/v2/auth/index.js
+++ b/Maddori.Apple-Server/routes/v2/auth/index.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = new express.Router({ mergeParams: true });
+
+// version 1 auth api (version 1 api 이용 유지)
+const {
+    signOut
+} = require('../../v1/auth/auth');
+
+// version 2 auth api
+
+// middlewares
+const {
+    userCheck,
+} = require('../../../middlewares/auth');
+
+// handler
+router.delete('/signOut', [userCheck], signOut);
+
+module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/index.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = new express.Router({ mergeParams: true });
+
+// version 1 feedbacks api (version 1 api 이용 유지)
+const {
+    createFeedback,
+    deleteFeedback
+} = require('../../v1/feedbacks/feedbacks');
+
+// version 2 feedbacks api
+
+// middlewares
+const {
+    userCheck,
+    userTeamCheck,
+    reflectionTimeCheck,
+    reflectionStateCheck,
+    teamReflectionRelationCheck,
+    reflectionFeedbackRelationCheck
+} = require('../../../middlewares/auth');
+const {
+    validateFeedback
+} = require('../../../middlewares/validate');
+
+// user auth 검증
+router.use('/', userCheck);
+// handler
+router.post('/', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before')], validateFeedback, createFeedback);
+router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck], deleteFeedback);
+
+module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/index.js
+++ b/Maddori.Apple-Server/routes/v2/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
 // 라우팅 (auth, users, teams, reflections, feedbacks 로 분리)
+router.use('/auth', require('./auth/index'));
 router.use('/users', require('./users/index'));
 router.use('/teams', require('./teams/index'));
 router.use('/teams/:team_id/reflections', require('./reflections/index'));

--- a/Maddori.Apple-Server/routes/v2/index.js
+++ b/Maddori.Apple-Server/routes/v2/index.js
@@ -6,5 +6,6 @@ router.use('/auth', require('./auth/index'));
 router.use('/users', require('./users/index'));
 router.use('/teams', require('./teams/index'));
 router.use('/teams/:team_id/reflections', require('./reflections/index'));
+router.use('/teams/:team_id/reflections/:reflection_id/feedbacks', require('./feedbacks/index'));
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/reflections/index.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/index.js
@@ -1,9 +1,19 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
+
+// version 1 reflections api (version 1 api 이용 유지)
+const {
+    getCurrentReflectionDetail,
+    getPastReflectionList
+} = require('../../v1/reflections/reflections');
+
+// version 2 reflections api
 const {
     updateReflectionDetail,
     endInProgressReflection
 } = require('./reflections');
+
+// middlewares
 const {
     userCheck,
     userTeamCheck,
@@ -20,6 +30,8 @@ const {
 router.use('/', userCheck);
 // handler
 router.patch('/:reflection_id/end', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], endInProgressReflection);
+router.get('/', [userTeamCheck], getPastReflectionList);
+router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);
 router.patch('/:reflection_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), validateReflectionname], updateReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/teams/index.js
+++ b/Maddori.Apple-Server/routes/v2/teams/index.js
@@ -1,10 +1,18 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
+// version 1 team api (version 1 api 이용 유지)
+const {
+    getCertainTeamName
+} = require('../../v1/teams/teams');
+
+// version 2 team api
 const {
     createTeam,
     getCertainTeamDetail
 } = require('./teams');
+
+// middlewares
 const {
     userCheck,
     userTeamCheck,
@@ -17,6 +25,7 @@ const {
 // user auth 검증
 router.use('/', userCheck);
 // handler
+router.get('/', getCertainTeamName);
 router.post('/', [validateTeamname], createTeam);
 router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);
 

--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -1,8 +1,17 @@
 const express = require('express');
 const router = new express.Router({ mergeParams: true });
+
+// version 1 users api (version 1 api 이용 유지)
+const {
+    userLeaveTeam
+} = require('../../v1/users/users');
+
+// version 2 users api
 const {
     userJoinTeam
 } = require('./users');
+
+// middlewares
 const {
     userCheck,
     userTeamCheck,
@@ -17,5 +26,6 @@ const {
 router.use('/', userCheck);
 // handler
 router.post('/join-team/:team_id', userJoinTeam);
+router.delete('/team/:team_id/leave', userLeaveTeam);
 
 module.exports = router;


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
v1.4 이후부터는 모든 api의 URI를 api/v2 형식으로 변경할 예정.
api에 변경사항이 없는 경우 기존에 구현된 api 버전을 사용하지만, api/v2 URI를 통해 사용할 수 있도록 한다.
따라서 아래 api에 접근하는 version2 URI 를 추가한다.
- getCertainTeamName v1
- getCurrentReflectionDetail v1
- signOut v1
- createFeedback v1
- userLeaveTeam v1
- deleteFeedback v1
- getPastReflectionList v1

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
routes/v2 내에서 아래와 같이 version 1 api를 모듈로 불러온 후 사용하는 방식으로 구현함.
```javascript
// version 1 feedbacks api (version 1 api 이용 유지)
const {
    createFeedback,
    deleteFeedback
} = require('../../v1/feedbacks/feedbacks');

// handler
router.post('/', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before')], validateFeedback, createFeedback);
router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck], deleteFeedback);

```

위와 같이 구현한다면
`/api/v2/teams/1/reflections/2/feedbacks`, `/api/v2/teams/1/reflections/2/feedbacks/20`
URI를 사용하여 version 1 api를 사용할 수 있음.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- getCertainTeamName
- getCurrentReflectionDetail
- signOut
- createFeedback
- userLeaveTeam
- deleteFeedback
- getPastReflectionList

위 api의 버전을 v1이 아닌 v2로 지정 후 호출해도 v1으로 호출했을 때와 같은 결과를 반환함.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
createFeedback 호출 예시
- `/api/v1/teams/1/reflections/2/feedbacks`
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/215118281-ac20a5a9-16f5-4595-a6ab-f3275ade58cc.png">

- `/api/v2/teams/1/reflections/2/feedbacks`
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/215118163-e7d31765-e310-465e-a00a-c927a3cd4509.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
만약 일부 api만 version1 URI를 사용하고 새로운 api만 version2 URI를 사용한다면 아래 문제가 발생할 수 있기에 모든 api의 버전을 업데이트하는 방법을 선택함.

- api별로 다른 버전을 사용하도록 한다면 클라이언트 개발에 혼동을 줄 수 있음
- api별로 최신 버전이 상이하기 때문에 api 관리가 체계적으로 이루어지기 어려움

모든 api의 버전 업데이트를 함께 진행하면 아래 문제가 발생할 수 있기 때문에 옳은 방법인지 확신할 수 없음

- 일부 api의 버전 업데이트만 필요해도 모든 api의 버전을 업데이트 하는 것은 규모가 매우 큼
- 코드의 중복이 크게 발생할 수 있음

위 문제에서 코드의 중복 문제를 최대한 해결하기 위해 주소만 version2 형식으로 지정하고 version1의 api를 그대로 사용하는 방법을 선택함.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #117 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
