### PR TITLE
[CHORE] appleLogin, userLogin, singOut version 1 API의 URI 변경

### DIFF
--- a/Maddori.Apple-Server/routes/v1/auth/index.js
+++ b/Maddori.Apple-Server/routes/v1/auth/index.js
@@ -11,6 +11,6 @@ const {
 } = require('./auth');
 
 router.post('/', appleLogin);
-router.delete('/signOut', [userCheck], signOut);
+router.delete('/signout', [userCheck], signOut);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v1/index.js
+++ b/Maddori.Apple-Server/routes/v1/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = new express.Router({ mergeParams: true });
 
 // 라우팅 (auth, users, teams, reflections, feedbacks 로 분리)
-router.use('/auth', require('./auth/index'));
+router.use('/login', require('./auth/index'));
 router.use('/users', require('./users/index'));
 router.use('/teams', require('./teams/index'));
 router.use('/teams/:team_id/reflections', require('./reflections/index'));

--- a/Maddori.Apple-Server/routes/v1/users/index.js
+++ b/Maddori.Apple-Server/routes/v1/users/index.js
@@ -18,7 +18,7 @@ const {
 // user auth 검증
 router.use('/', userCheck);
 // handler
-router.post('/nickName', [validateUsername], userLogin);
+router.post('/login', [validateUsername], userLogin);
 router.post('/join-team/:team_id', userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
현재 배포된 버전의 앱/ 서버에 변경된 URI가 적용되어 있지 않음
따라서 appleLogin, userLogin, signOut을 변경 전 URI로 수정이 필요
= https://github.com/hwiwonK/MacC-Team-Maddori.Apple-Server/pull/96 의 변경사항 되돌리기

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- appleLogin version 1 URI 변경
  `{{host}}/api/v1/login`
- signOut version 1 URI 변경
  `{{host}}/api/v1/login/signout`
- userLogin version 1 URI 변경
  `{{host}}/api/v1/users/login`

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
변경된 URI로 api 테스트 진행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
version 2에는 96번 PR로 수정되었던 URI가 적용되어있는 상태입니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #119 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
