### PR TITLE
[FEAT] createTeam, userJoinTeam api v2 response 형식 변경

### DIFF
--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -64,7 +64,7 @@ async function createTeam(req, res, next) {
         const imagePath = req.file.path.split('resources')[1]
 
         // userteam 테이블 업데이트(팀 합류 및 프로필 생성)
-        let createdProfile = await userteam.create({
+        let createdUserteam = await userteam.create({
             user_id: user_id,
             team_id: createdTeam.id,
             nickname: nickname,
@@ -73,8 +73,16 @@ async function createTeam(req, res, next) {
         });
 
         // v1.4 이후로 사용하지 않는 admin 필드는 반환하지 않음
-        createdProfile = createdProfile.dataValues;
-        delete createdProfile.admin;
+        let createdProfile = await userteam.findByPk(createdUserteam.id, {
+            attributes: ['id', 'nickname', 'role', 'profile_image_path', 'user_id'],
+            include: [
+                {
+                    model: team, 
+                    where: { id: createdUserteam.team_id },
+                    attributes: ['id', 'team_name', 'invitation_code']
+                }
+            ]
+        });
         
         res.status(201).json({
             success: true,

--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -73,7 +73,7 @@ async function createTeam(req, res, next) {
         });
 
         // v1.4 이후로 사용하지 않는 admin 필드는 반환하지 않음
-        let createdProfile = await userteam.findByPk(createdUserteam.id, {
+        const createdProfile = await userteam.findByPk(createdUserteam.id, {
             attributes: ['id', 'nickname', 'role', 'profile_image_path', 'user_id'],
             include: [
                 {

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -18,7 +18,7 @@ async function userJoinTeam(req, res, next) {
         const imagePath = req.file.path.split('resources')[1]
 
         // userteam 테이블 업데이트(팀 합류 및 프로필 생성)
-        let [createdProfile, created] = await userteam.findOrCreate({
+        let [createdUserteam, created] = await userteam.findOrCreate({
             where: {
                 user_id: user_id,
                 team_id: team_id
@@ -35,8 +35,16 @@ async function userJoinTeam(req, res, next) {
         if (created === false) throw Error('이미 유저가 해당 팀에 합류된 상태');
 
         // v1.4 이후로 사용하지 않는 admin 필드는 반환하지 않음
-        createdProfile = createdProfile.dataValues;
-        delete createdProfile.admin;
+        const createdProfile = await userteam.findByPk(createdUserteam.id, {
+            attributes: ['id', 'nickname', 'role', 'profile_image_path', 'user_id'],
+            include: [
+                {
+                    model: team, 
+                    where: { id: createdUserteam.team_id },
+                    attributes: ['id', 'team_name', 'invitation_code']
+                }
+            ]
+        });
               
         res.status(201).json({
             success: true,


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
createTeam api response에서 팀 이름, 초대 코드가 필요함
createTeam, userJoinTeam은 같은 형식의 response를 활용하도록 변경

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 아래와 같이 두 api의 response 형식 변경
```json
{
    "success": true,
    "message": "팀 생성 및 팀 합류 완료",
    "detail": {
        "id": 40,
        "nickname": "새로운닉네임",
        "role": "개발자이",
        "profile_image_path": "/profile_images/1675096431730-스크린샷 2022-08-04 오후 12.17.28.png",
        "user_id": 1,
        "team": {
            "id": 26,
            "team_name": "마지",
            "invitation_code": "ZTUH6I"
        }
    }
}
```

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
createTeam v2, userJoinTeam v2 api 실행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #123 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
