### PR TITLE
[CHORE] profile_image null 허용

### DIFF
--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -61,7 +61,7 @@ async function createTeam(req, res, next) {
         });
 
         // 프로필 이미지 저장된 경로 구하기
-        const imagePath = req.file.path.split('resources')[1]
+        const imagePath = req.file ? req.file.path.split('resources')[1] : null;
 
         // userteam 테이블 업데이트(팀 합류 및 프로필 생성)
         let createdUserteam = await userteam.create({

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -15,7 +15,7 @@ async function userJoinTeam(req, res, next) {
         if (requestTeam === null) throw Error('요청하는 팀이 존재하지 않음');
 
         // 프로필 이미지 저장된 경로 구하기
-        const imagePath = req.file.path.split('resources')[1]
+        const imagePath = req.file ? req.file.path.split('resources')[1] : null;
 
         // userteam 테이블 업데이트(팀 합류 및 프로필 생성)
         let [createdUserteam, created] = await userteam.findOrCreate({


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
프로필 이미지 null일 경우 아래와 같은 에러 발생
```json
{
    "success": false,
    "message": "팀 생성 및 팀 합류 실패",
    "detail": "Cannot read properties of undefined (reading 'path')"
}
```

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 프로필 이미지가 null일 경우 정상 처리되도록 수정
  삼항 연산자 활용
  `const imagePath = req.file ? req.file.path.split('resources')[1] : null;`

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
createTeam, userJoinTeam v2 실행 (파일 넘겨주지 않고 실행)

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- userJoinTeam v2
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/215665734-b859b74e-9b24-443a-906a-8154e74aaa60.png">

- createTeam v2
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/215665801-430dc64d-6477-4297-b1c6-2101a33b70ec.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #125 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
