### PR TITLE
[FEAT] 유저 이름 저장 테이블 변경에 따른 api 버전 업데이트

### DIFF
--- a/Maddori.Apple-Server/routes/v2/auth/auth.js
+++ b/Maddori.Apple-Server/routes/v2/auth/auth.js
@@ -1,0 +1,126 @@
+const {user, team, userteam, reflection, feedback, usertoken } = require('../../../models');
+const jwtUtil = require('../../../utils/jwt.util');
+
+// request data: identity token
+// response data: access_token, refresh_token, user 정보(id, db상 가장 상위에 참여하고 있는 팀 id)
+// apple social login을 진행하고, 토큰을 발급한다.
+const appleLogin = async (req, res, next) => {
+    const { token } = req.body;
+
+    try {
+        // identity token 검증 위한 공개키 생성하기
+        let publicKeyPem;
+        await jwtUtil.generateKey(token).then((result) => {
+            if (result.type === false) {
+                // public key 생성 오류는 서버 에러로 처리
+                return res.status(500).json({
+                    success: false,
+                    message: '유저 로그인 실패',
+                    detail: '서버 오류'
+                })
+            }
+            publicKeyPem = result.key;
+        });
+
+        // 공개키를 사용한 identity token 검증 및 identity token 값에서 user 정보 가져오기
+        let decoded;
+        await jwtUtil.verify(token, publicKeyPem).then((result) => {
+            if (result.type === false) {
+                throw Error(result.message);
+            }
+            decoded = result.decoded;
+        });
+        const { email, sub, ...others } = decoded;
+    
+        // 이미 있는 user인지 확인하기
+        const [loginedUser, created] = await user.findOrCreate({
+            where: {
+                sub: sub,
+            },
+            defaults: {
+                sub: sub,
+                email: email
+            },
+            include: {
+                attributes: ['team_id'],
+                model: userteam         
+            },
+            raw: true
+        });
+
+        // 이미 있는 유저였고, 유저의 이메일이 변경되었다면 이메일 업데이트
+        if (loginedUser.email !== email) {
+            const updatedUser = await user.update({
+                email: email,
+            }, {
+                where: {
+                    sub: sub
+                }
+            });
+        }
+
+        // token 생성
+        const accessToken = await jwtUtil.sign(loginedUser.id);
+        const refreshToken = await jwtUtil.refresh(loginedUser.id);        
+        
+        // 이미 있는 user일 경우
+        if (created === false) {
+            // refresh token db에 업데이트
+            await usertoken.update({
+                refresh_token: refreshToken,
+            },{
+                where: {
+                    user_id: loginedUser.id
+                }
+            });
+
+            return res.status(200).json({
+                success: true,
+                message: '유저 로그인 성공',
+                detail: {
+                    created: false,
+                    access_token: accessToken,
+                    refresh_token: refreshToken,
+                    user: {
+                        user_id: loginedUser.id,
+                        team_id: loginedUser['userteams.team_id'] ?? null    
+                    }
+                }
+            });
+        } else {
+            // 새로 생성된 user일 경우
+            // refresh token db에 업데이트
+            await usertoken.create({
+                user_id: loginedUser.id,
+                refresh_token: refreshToken
+            });
+
+            return res.status(200).json({
+                success: true,
+                message: '유저 회원가입과 로그인 성공',
+                detail: {
+                    created: true,
+                    access_token: accessToken,
+                    refresh_token: refreshToken,
+                    user: {
+                        user_id: loginedUser.id,
+                        team_id: null    
+                    }
+                }
+            });
+        }
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '유저 로그인 실패',
+            detail: error.message
+        });
+    }
+}
+
+
+module.exports = {
+    appleLogin
+}

--- a/Maddori.Apple-Server/routes/v2/auth/index.js
+++ b/Maddori.Apple-Server/routes/v2/auth/index.js
@@ -7,6 +7,9 @@ const {
 } = require('../../v1/auth/auth');
 
 // version 2 auth api
+const {
+    appleLogin
+} = require('./auth');
 
 // middlewares
 const {
@@ -15,5 +18,6 @@ const {
 
 // handler
 router.delete('/signOut', [userCheck], signOut);
+router.post('/', appleLogin);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/feedbacks.js
@@ -1,0 +1,60 @@
+const {user, team, userteam, reflection, feedback, Sequelize } = require('../../../models');
+const { Op } = require("sequelize");
+
+// request data: team_id, reflection_id, type
+// response data: id, type, keyword, content, from_user 정보 (id, nickname)
+// 특정 회고에서 사용자가 받은 특정 type의 feedback 리스트를 불러온다
+const getCertainTypeFeedbackAll = async (req, res, next) => {
+    try {
+        const user_id = req.user_id;
+        const { type } = req.query;
+        const { team_id, reflection_id } = req.params;
+
+        // 피드백을 보낸 사람의 정보 포함하여 피드백 조회
+        const feedbackData = await feedback.findAll({
+            where: {
+                team_id: team_id,
+                reflection_id: reflection_id,
+                type: type,
+                to_id: user_id,
+            },
+            include: [
+                {
+                    model: user,
+                    attributes: [
+                        'id',
+                        [Sequelize.literal('nickname'), 'nickname'],
+                    ],
+                    as: 'from_user',
+                    include: [
+                        {
+                            model: userteam,
+                            attributes: []
+                        }
+                    ]
+                }
+            ],
+            attributes: [
+                'id', 'type', 'keyword', 'content'
+            ]
+        });
+
+        return res.status(200).json({
+            'success': true,
+            'message': '피드백 정보 조회 성공',
+            'detail': {
+                'feedback': feedbackData
+            }
+        });
+    } catch (error) {
+        return res.status(400).json({
+            'success': false,
+            'message': '피드백 정보 조회 실패',
+            'detail': error.message
+        })
+    }
+}
+
+module.exports = {
+    getCertainTypeFeedbackAll
+}

--- a/Maddori.Apple-Server/routes/v2/feedbacks/feedbacks.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/feedbacks.js
@@ -35,7 +35,7 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
                 }
             ],
             attributes: [
-                'id', 'type', 'keyword', 'content'
+                'id', 'type', 'keyword', 'content', 'team_id', 'reflection_id'
             ]
         });
 
@@ -55,6 +55,79 @@ const getCertainTypeFeedbackAll = async (req, res, next) => {
     }
 }
 
+/** request data: team_id, reflection_id, feedback_id, css_type, keyword, content
+    response data: id, type, keyword, content, from_user 정보 (id, nickname), 
+    team_id, reflection_id, reflection_name, 보내는 user_name
+    특정 피드백을 수정하는 API, 현재 진행중인 회고는 수정이 불가능하다. **/
+const updateFeedback = async (req, res, next) => {
+    try {
+        const user_id = req.user_id;
+        const { feedback_id } = req.params
+        const { type, keyword, content} = req.body;
+
+        // 피드백을 작성한 유저가 요청을 보낸 유저가 아닐 경우 에러 반환
+        const checkFeedbackDataFromUser = await feedback.findByPk(feedback_id);
+        if (checkFeedbackDataFromUser.from_id !== parseInt(user_id)) throw Error('타 유저가 작성한 피드백에 대한 수정 권한 없음');
+
+        // 피드백 타입 오류에 대한 에러 반환
+        if (!(type === 'Continue' || type === 'Stop')) {
+            return res.status(400).json({
+                'success': false,
+                'message': '피드백의 타입정보 오류'
+            })
+        };
+
+        // 피드백 업데이트 수행
+        const updatedFeedbackData = await feedback.update({
+            type: type,
+            keyword: keyword,
+            content: content,
+        },{ 
+            where: {
+                id: feedback_id,
+            },
+        });
+
+        const resultFeedbackData = await feedback.findByPk(feedback_id,
+        {
+            include: [
+                {
+                    model: user,
+                    attributes: [
+                        'id',
+                        [Sequelize.literal('nickname'), 'nickname'],
+                    ],
+                    as: 'to_user',
+                    include: [
+                        {
+                            model: userteam,
+                            attributes: []
+                        }
+                    ]
+                }
+            ],
+            attributes: [
+                'id', 'type', 'keyword', 'content', 'team_id', 'reflection_id'
+            ]
+        });
+
+        return res.status(200).json({
+            'success': true,
+            'message': '피드백 정보 수정 성공',
+            'detail': resultFeedbackData
+        });
+        
+    } catch (error) {
+        return res.status(400).json({
+            'success': false,
+            'message': '피드백 정보 수정 실패',
+            'detail': error.message
+        });
+    }
+    
+}
+
 module.exports = {
-    getCertainTypeFeedbackAll
+    getCertainTypeFeedbackAll,
+    updateFeedback
 }

--- a/Maddori.Apple-Server/routes/v2/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/index.js
@@ -10,7 +10,8 @@ const {
 // version 2 feedbacks api
 const {
     getCertainTypeFeedbackAll,
-    updateFeedback
+    updateFeedback,
+    getTeamAndUserFeedback
 } = require('./feedbacks');
 
 // middlewares
@@ -34,6 +35,6 @@ router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, refl
 router.get('/', [userTeamCheck, teamReflectionRelationCheck, reflectionStateCheck('Done')], getCertainTypeFeedbackAll);
 router.put('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck, validateFeedback], updateFeedback);
 // router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before', 'Progressing')], getFromMeToCertainMemberFeedbackAll);
-// router.get('/from-team', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], getTeamAndUserFeedback);
+router.get('/from-team', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing', 'Done')], getTeamAndUserFeedback);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/index.js
@@ -9,7 +9,8 @@ const {
 
 // version 2 feedbacks api
 const {
-    getCertainTypeFeedbackAll
+    getCertainTypeFeedbackAll,
+    updateFeedback
 } = require('./feedbacks');
 
 // middlewares
@@ -31,7 +32,7 @@ router.use('/', userCheck);
 router.post('/', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before')], validateFeedback, createFeedback);
 router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck], deleteFeedback);
 router.get('/', [userTeamCheck, teamReflectionRelationCheck, reflectionStateCheck('Done')], getCertainTypeFeedbackAll);
-// router.put('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck, validateFeedback], updateFeedback);
+router.put('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck, validateFeedback], updateFeedback);
 // router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before', 'Progressing')], getFromMeToCertainMemberFeedbackAll);
 // router.get('/from-team', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], getTeamAndUserFeedback);
 

--- a/Maddori.Apple-Server/routes/v2/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/index.js
@@ -8,6 +8,9 @@ const {
 } = require('../../v1/feedbacks/feedbacks');
 
 // version 2 feedbacks api
+const {
+    getCertainTypeFeedbackAll
+} = require('./feedbacks');
 
 // middlewares
 const {
@@ -27,5 +30,9 @@ router.use('/', userCheck);
 // handler
 router.post('/', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before')], validateFeedback, createFeedback);
 router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck], deleteFeedback);
+router.get('/', [userTeamCheck, teamReflectionRelationCheck, reflectionStateCheck('Done')], getCertainTypeFeedbackAll);
+// router.put('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck, validateFeedback], updateFeedback);
+// router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before', 'Progressing')], getFromMeToCertainMemberFeedbackAll);
+// router.get('/from-team', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing')], getTeamAndUserFeedback);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/index.js
@@ -11,7 +11,8 @@ const {
 const {
     getCertainTypeFeedbackAll,
     updateFeedback,
-    getTeamAndUserFeedback
+    getTeamAndUserFeedback,
+    getFromMeToCertainMemberFeedbackAll
 } = require('./feedbacks');
 
 // middlewares
@@ -34,7 +35,7 @@ router.post('/', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeChec
 router.delete('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck], deleteFeedback);
 router.get('/', [userTeamCheck, teamReflectionRelationCheck, reflectionStateCheck('Done')], getCertainTypeFeedbackAll);
 router.put('/:feedback_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), reflectionFeedbackRelationCheck, validateFeedback], updateFeedback);
-// router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before', 'Progressing')], getFromMeToCertainMemberFeedbackAll);
+router.get('/from-me', [userTeamCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before', 'Progressing')], getFromMeToCertainMemberFeedbackAll);
 router.get('/from-team', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('Progressing', 'Done')], getTeamAndUserFeedback);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/feedbacks/index.js
+++ b/Maddori.Apple-Server/routes/v2/feedbacks/index.js
@@ -3,12 +3,12 @@ const router = new express.Router({ mergeParams: true });
 
 // version 1 feedbacks api (version 1 api 이용 유지)
 const {
-    createFeedback,
     deleteFeedback
 } = require('../../v1/feedbacks/feedbacks');
 
 // version 2 feedbacks api
 const {
+    createFeedback,
     getCertainTypeFeedbackAll,
     updateFeedback,
     getTeamAndUserFeedback,


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
유저가 팀별로 각기 다른 nickname을 가지며, 그 정보는 userteam 테이블에 저장됨
기존에는 user 테이블에 username이 함께 저장되었으므로, 유저의 이름을 가져오는 로직 수정 필요.

또한 version 1에서는 피드백, 회고 등의 데이터 response가 통일되지 않았음. 따라서 version 2에서는 같은 정보라면 최대한 통일된 형식의 response를 가지도록 수정이 필요.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 다음 api의 version2 생성
- getFromMeToCertainMemberFeedbackAll
- updateFeedback
- getTeamAndUserFeedback
- getCertainTypeFeedbackAll
- appleLogin
- createFeedback

### response의 형식 통일
- user의 기본 정보 (to_user 혹은 from_user)
  createFeedback, updateFeedback, getTeamAndUserFeedback, getFromMeToCertainMemberFeedback, getCertainTypeFeedback 에서 사용
   ```json
  "to_user": {
      "id": 2,
      "nickname": "진저"
  }
   ```
- feedback 정보
  createFeedback, updateFeedback, getTeamAndUserFeedback, getFromMeToCertainMemberFeedback, getCertainTypeFeedback 에서 사용
   ```json
  {
     "id": 5,
     "type": "Continue",
     "keyword": "c",
     "content": "지속하기"
  }
   ```

- reflection 정보
  getFromMeToCertainMemberFeedbackAll
  ```json
  "reflection": {
      "id": 2,
      "reflection_name": "맛쟁이사과처럼 sprint2",
      "date": null,
      "state": "Progressing",
      "team_id": 1
  },
   ```

### userteam을 통해 유저의 nickname 가져오도록 수정

`include`와 `Sequelize.literal` 문법을 사용하여 구현
userteam과 feedback 테이블 사이에는 association이 없기 때문에, feedback-user-userteam을 join하는 multiple join 수행
```javascript
        const feedbackData = await feedback.findAll({
            where: {
                team_id: team_id,
                reflection_id: reflection_id,
                type: type,
                to_id: user_id,
            },
            include: [
                {
                    model: user,
                    attributes: [
                        'id',
                        [Sequelize.literal('nickname'), 'nickname'],
                    ],
                    as: 'from_user',
                    include: [
                        {
                            model: userteam,
                            attributes: []
                        }
                    ]
                }
            ],
            attributes: [
                'id', 'type', 'keyword', 'content'
            ]
        });
```

### appleLogin version 2 개발
유저는 여러 팀에 속할 수 있고, 만약 유저가 여러 팀에 소속되어 있다면 제일 먼저 합류한 팀의 id를 반환

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
createFeedback, updateFeedback, getTeamAndUserFeedback, getFromMeToCertainMemberFeedback, getCertainTypeFeedback, appleLogin version 2 수행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
response 데이터가 공통된 형식을 가지도록 하기 위해 구현하다보니 일부 api의 response에는 불필요한 정보가 포함되는 경우가 생김.
어떤 것을 우선시해야 할지 고민이 필요함.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #127 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://sequelize.org/docs/v6/core-concepts/model-querying-basics/
외 Sequelize 공식 문서