### PR TITLE
[FEAT] getTeamMembers version 2 api 구현

### DIFF
--- a/Maddori.Apple-Server/routes/v2/teams/index.js
+++ b/Maddori.Apple-Server/routes/v2/teams/index.js
@@ -9,7 +9,8 @@ const {
 // version 2 team api
 const {
     createTeam,
-    getCertainTeamDetail
+    getCertainTeamDetail,
+    getTeamMembers
 } = require('./teams');
 
 // middlewares
@@ -32,5 +33,6 @@ router.use('/', userCheck);
 router.get('/', getCertainTeamName);
 router.post('/', uploadFile, [validateTeamname, validateNickname], createTeam);
 router.get('/:team_id', [userTeamCheck], getCertainTeamDetail);
+router.get('/:team_id/members', [userTeamCheck], getTeamMembers);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/teams/teams.js
+++ b/Maddori.Apple-Server/routes/v2/teams/teams.js
@@ -131,7 +131,44 @@ async function getCertainTeamDetail(req, res, next) {
     }
 }
 
+/** request data : user_id, team_id
+    response data : [user_id, nickname, role, profile_image_path]
+    팀에 속한 유저(멤버) 목록 가져오기 **/
+const getTeamMembers = async (req, res, next) => {
+    // console.log("팀 멤버 목록 가져오기");
+    const { team_id } = req.params;
+    try {
+        const user_id = req.user_id;
+        // 멤버 목록 가져오기
+        const teamMemberList = await userteam.findAll({
+            attributes: [['user_id', 'id'], 'nickname', 'role', 'profile_image_path'],
+            where: {
+                team_id : team_id
+            }  
+        });
+        // 일치하는 팀 정보가 없는 경우 에러 반환
+        if (teamMemberList.length === 0) { throw Error('팀이 존재하지 않음'); }
+
+        res.status(200).json({
+            success: true,
+            message: '팀의 멤버 목록 가져오기 성공',
+            detail: {
+                members : teamMemberList
+            }
+        });
+
+    } catch (error) {
+        // TODO: 에러 처리 수정
+        res.status(400).json({
+            success: false,
+            message: '팀의 멤버 목록 가져오기 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
     createTeam,
-    getCertainTeamDetail
+    getCertainTeamDetail,
+    getTeamMembers
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
getTeamMembers version 1 api : 팀에 속한 멤버의 id, 이름을 반환
getTeamMembers version 2 api는 팀에 속한 멤버의 프로필(닉네임, 역할, 프로필 사진)을 배열 형식으로 반환해야 합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- getTeamMembers v2 개발
  userteam 테이블에서 params로 받은 team_id와 일치하는 회원 리스트를 반환(프로필 정보와 user_id 정보 포함)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- getTeamMembers v2 api 실행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="746" alt="image" src="https://user-images.githubusercontent.com/67336936/216999548-cddad840-9bfa-4124-8cc8-9484c638707e.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
항상 클라이언트에 결과를 어떤 형식으로 보여줘야 할지 고민이 많이 되는 것 같음.
바로 리스트를 반환할지 어떤 리스트인지를 명시해야 할지 고민을 했고, 결과의 의미를 명확하게 전달하기 위해 아래와 같이 응답 형식을 결정함.
`'members' : [member의 리스트]`

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #129 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
