### PR TITLE
[FEAT] 프로필 수정 api 개발

### DIFF
--- a/Maddori.Apple-Server/middlewares/validate.js
+++ b/Maddori.Apple-Server/middlewares/validate.js
@@ -1,5 +1,6 @@
 const { text } = require('express');
 const { body, validationResult } = require('express-validator');
+const fs = require('fs');
 
 // 글자 수 제한 값
 const textLimit = {
@@ -97,6 +98,14 @@ const validateNickname = [
     (req, res, next) => {
         const errors = validationResult(req);
         if (!errors.isEmpty()) {
+            // uploadFile에서 서버에 저장된 프로필 이미지 파일 삭제
+            if (req.file) {
+                try {
+                    fs.unlinkSync(__basedir + '/resources' + req.file.path.split('resources')[1]);
+                } catch (error) {
+                    // console.log(error);
+                }
+            }
             return res.status(400).json({
                 success: false,
                 message: '입력 값의 형식이 잘못됨',

--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -8,7 +8,8 @@ const {
 
 // version 2 users api
 const {
-    userJoinTeam
+    userJoinTeam,
+    editProfile
 } = require('./users');
 
 // middlewares
@@ -30,5 +31,6 @@ router.use('/', userCheck);
 // handler
 router.post('/join-team/:team_id', uploadFile, [validateNickname], userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
+router.put('/teams/:team_id/profile', editProfile);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -31,6 +31,6 @@ router.use('/', userCheck);
 // handler
 router.post('/join-team/:team_id', uploadFile, [validateNickname], userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
-router.put('/teams/:team_id/profile', uploadFile, [validateNickname], editProfile);
+router.put('/teams/:team_id/profile', userTeamCheck, uploadFile, [validateNickname], editProfile);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -31,6 +31,6 @@ router.use('/', userCheck);
 // handler
 router.post('/join-team/:team_id', uploadFile, [validateNickname], userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
-router.put('/teams/:team_id/profile', editProfile);
+router.put('/teams/:team_id/profile', uploadFile, [validateNickname], editProfile);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -62,6 +62,30 @@ async function userJoinTeam(req, res, next) {
     }
 }
 
+const editProfile = async (req, res) => {
+    
+    const user_id = req.user_id;
+    const { team_id } = req.params;
+    const { nickname, role } = req.body;
+
+    try {
+
+        res.status(201).json({
+            success: true,
+            message: '유저 프로필 수정 성공',
+            detail: '수정된 프로필'
+        });
+
+    } catch (error) {
+        res.status(400).json({
+            success: false,
+            message: '유저 프로필 수정 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
-    userJoinTeam
+    userJoinTeam,
+    editProfile
 };

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -1,4 +1,7 @@
 const {user, team, userteam, reflection, feedback} = require('../../../models');
+const fs = require('fs');
+const path = require('path');
+__basedir = path.resolve();
 
 // request data : user_id, team_id
 // response data : userteam_id, user_id, team_id
@@ -69,11 +72,56 @@ const editProfile = async (req, res) => {
     const { nickname, role } = req.body;
 
     try {
+        // 기존 이미지 삭제
+        const { profile_image_path } = await userteam.findOne({
+            attributes: ['profile_image_path'],
+            where: {
+                user_id: user_id,
+                team_id: team_id
+            },
+            raw: true
+        })
+
+        // 기존 이미지 파일이 서버에 존재한다면 삭제
+        const fullImagePath = __basedir + '/resources' + profile_image_path;
+        const changedImagePath = req.file ? req.file.path.split('resources')[1] : null;
+        // 기존 이미지 파일 삭제 실패한 경우 에러 반환, 기존 이미지 파일이 존재하지 않을 경우는 그대로 진행
+        try {
+            fs.unlinkSync(fullImagePath);
+        } catch (error) {
+            if (error.code !== 'ENOENT') {
+                fs.unlikeSync(changedImagePath);
+                return res.status(500).json({
+                    success: false,
+                    message: '유저 프로필 수정 실패',
+                    detail: '서버 오류'
+                })
+            }
+        }
+
+        // 프로필 수정 사항 반영
+        await userteam.update({
+            nickname: nickname,
+            role: role,
+            profile_image_path: changedImagePath
+        },{
+            where: {
+                user_id: user_id,
+                team_id: team_id
+        }});
+        // 수정된 프로필 조회 후 response
+        const editedProfile = await userteam.findOne({
+            attributes: [['user_id', 'id'], 'nickname', 'role', 'profile_image_path'],
+            where: {
+                user_id: user_id,
+                team_id: team_id
+            }
+        });
 
         res.status(201).json({
             success: true,
             message: '유저 프로필 수정 성공',
-            detail: '수정된 프로필'
+            detail: editedProfile
         });
 
     } catch (error) {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
v1.4 부터 프로필 수정 기능 추가
아래 조건에 맞게 프로필 수정 api를 설계하고 개발한다.
- 닉네임, 역할, 프로필 이미지와 함께 PUT 요청이 들어온다.
- 기존에 저장된 프로필 이미지를 삭제하고 업데이트한다.
- 닉네임, 역할의 글자수 제한을 검증한다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- editProfle api 설계
  URI : {{host}}/api/v2/users/teams/:team_id/profile
  request body : nickname, role, profile_image
  리소스의 계층을 표현하기 위해 위와 같이 설계함 (유저의 팀 중 특정 팀에서 유저가 사용하는 프로필)
- editProfile v2 api 구현
  1. 새로운 프로필 이미지 파일을 서버에 저장한다
  2. 닉네임 형식을 검증한다 (에러 발생시 앞선 과정에서 저장된 이미지 서버에서 삭제)
  4. 기존 프로필 이미지 파일을 찾고 삭제한다
  5. userteams 테이블에 새로운 프로필 정보를 업데이트한다(닉네임, 역할, 새로운 프로필 이미지의 서버 저장 경로)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- editProfile v2 api 실행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
<img width="647" alt="image" src="https://user-images.githubusercontent.com/67336936/217189291-e65151a8-af39-4f17-8281-879e13e3a24c.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
이미지 삭제 요청/ 이미지 수정 요청/ 이미지 유지 요청을 구분할 수 없다

- 이미지 삭제, 이미지 수정 모두 req.file 값은 null로 받게 된다
- 이미지가 변경되지 않더라도 서버 입장에서는 요청으로 받은 이미지 값이 기존에 저장되어있던 이미지와 같은지 알 수 없다

→ 매번 이미지 삭제/업로드가 반복된다는 문제점이 발생한다
→ 이미지 삭제/ 이미지 수정 요청을 분리한다면 이 문제를 일부 해결할 수 있다
**요청을 분리하는 방법 외에 이미지의 삭제, 업로드 과정의 반복을 최소화 하는 방법을 찾아봐야할 것 같다.**
**이미지 삭제 로직이 반복되기 때문에 함수로 분리해야할 것 같다.**

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #131 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://any-ting.tistory.com/21