### PR TITLE
[FEAT] 유저의 팀 목록 가져오기, 회고 정보 삭제 api 개발

### DIFF
--- a/Maddori.Apple-Server/routes/v2/reflections/index.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/index.js
@@ -10,7 +10,8 @@ const {
 // version 2 reflections api
 const {
     updateReflectionDetail,
-    endInProgressReflection
+    endInProgressReflection,
+    deleteReflectionDetail
 } = require('./reflections');
 
 // middlewares
@@ -33,5 +34,6 @@ router.patch('/:reflection_id/end', [userTeamCheck, teamReflectionRelationCheck,
 router.get('/', [userTeamCheck], getPastReflectionList);
 router.get('/current', [userTeamCheck, reflectionTimeCheck], getCurrentReflectionDetail);
 router.patch('/:reflection_id', [userTeamCheck, teamReflectionRelationCheck, reflectionTimeCheck, reflectionStateCheck('SettingRequired', 'Before'), validateReflectionname], updateReflectionDetail);
+router.delete('/:reflection_id', [userTeamCheck, teamReflectionRelationCheck, reflectionStateCheck('SettingRequired', 'Before')], deleteReflectionDetail);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/reflections/reflections.js
+++ b/Maddori.Apple-Server/routes/v2/reflections/reflections.js
@@ -101,7 +101,44 @@ const endInProgressReflection = async (req, res, next) => {
     }
 }
 
+// request data : user_id, team_id, reflection_id
+// response data : reflection_id, reflection_name, date, status
+// 팀의 멤버가 팀의 현재 회고의 디테일 정보를 초기화한다
+const deleteReflectionDetail = async (req, res, next) => {
+
+    try {
+        const user_id = req.user_id;
+        const { reflection_id } = req.params;
+
+        // 피드백 상세 정보 삭제 (reflection_name과 date를 null로 설정하고 state를 변경한다)
+        const updateReflectionSuccess = await reflection.update({
+            reflection_name: null,
+            date: null,
+            state: 'SettingRequired'
+        }, {
+            where: {
+                id: reflection_id,
+            },
+        });
+        const reflectionDetail = await reflection.findByPk(reflection_id);
+
+        res.status(200).json({
+            success: true,
+            message: '회고 디테일 정보 삭제 성공',
+            detail: reflectionDetail
+        });
+
+    } catch (error) {
+        res.status(400).json({
+            success: false,
+            message: '회고 디테일 정보 삭제 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
     updateReflectionDetail,
-    endInProgressReflection
+    endInProgressReflection,
+    deleteReflectionDetail
 };

--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -9,7 +9,8 @@ const {
 // version 2 users api
 const {
     userJoinTeam,
-    editProfile
+    editProfile,
+    getUserTeamList
 } = require('./users');
 
 // middlewares
@@ -32,5 +33,6 @@ router.use('/', userCheck);
 router.post('/join-team/:team_id', uploadFile, [validateNickname], userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
 router.put('/teams/:team_id/profile', userTeamCheck, uploadFile, [validateNickname], editProfile);
+router.get('/teams', getUserTeamList);
 
 module.exports = router;

--- a/Maddori.Apple-Server/routes/v2/users/users.js
+++ b/Maddori.Apple-Server/routes/v2/users/users.js
@@ -1,4 +1,5 @@
 const {user, team, userteam, reflection, feedback} = require('../../../models');
+const Sequelize = require('sequelize');
 const fs = require('fs');
 const path = require('path');
 __basedir = path.resolve();
@@ -133,7 +134,40 @@ const editProfile = async (req, res) => {
     }
 }
 
+const getUserTeamList = async (req, res) => {
+    
+    const user_id = req.user_id;
+    
+    try {
+        // 유저가 속한 팀의 id와 팀 name 가져오기
+        const userTeamList = await userteam.findAll({
+            attributes: [['team_id', 'id'], [Sequelize.literal('team_name'), 'team_name']],
+            where: {
+                user_id: user_id
+            },
+            include: {
+                attributes: [],
+                model: team
+            }
+        });
+
+        res.status(200).json({
+            success: true,
+            message: '유저의 팀 목록 가져오기 성공',
+            detail: userTeamList
+        });
+
+    } catch (error) {
+        res.status(400).json({
+            success: false,
+            message: '유저의 팀 목록 가져오기 실패',
+            detail: error.message
+        });
+    }
+}
+
 module.exports = {
     userJoinTeam,
-    editProfile
+    editProfile,
+    getUserTeamList
 };


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 유저의 팀 목록 가져오기 기능 필요
  (v 1.4 이후로 유저가 여러 팀에 합류 가능해짐에 따름)
- 회고 정보 삭제 기능 필요
  현재 존재하는 updateReflectionDetail은 수정에만 사용 가능

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- getUserTeamList api 개발 (유저의 팀 목록 가져오기)
  userteam테이블과 team 테이블을 조인하여 속한 팀의 id와 team_name 리스트를 반환하도록 구현함.
- deleteReflectionDetail api 개발 (회고 정보 삭제하기)
  - 시간이 지난 회고를 삭제할 수 없도록 제한함.
    시간이 지난 회고 정보가 삭제 가능하도록 한다면 이미 회고 진행 프로세스에 들어간 사용자에게 에러 발생 가능하기 때문
  - SettingRequired, Before 상태에서만 정보 삭제가 가능한 것으로 설정함.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
getUserTeamList, deleteReflectionDetail 실행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- getUserTeamList
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/217844996-17cda7c3-2510-41c4-94c7-13348954e5ca.png">

- deleteReflectionDetail
<img width="500" alt="image" src="https://user-images.githubusercontent.com/67336936/217845121-15c92353-9409-472c-83e1-fff51ac7da7b.png">


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #135 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
