### PR TITLE
[FEAT] editProfile patch로 수정

### DIFF
--- a/Maddori.Apple-Server/routes/v2/users/index.js
+++ b/Maddori.Apple-Server/routes/v2/users/index.js
@@ -32,7 +32,7 @@ router.use('/', userCheck);
 // handler
 router.post('/join-team/:team_id', uploadFile, [validateNickname], userJoinTeam);
 router.delete('/team/:team_id/leave', userLeaveTeam);
-router.put('/teams/:team_id/profile', userTeamCheck, uploadFile, [validateNickname], editProfile);
+router.patch('/teams/:team_id/profile', userTeamCheck, uploadFile, [validateNickname], editProfile);
 router.get('/teams', getUserTeamList);
 
 module.exports = router;


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
프로필 사진 삭제하기 기능은 없기에 editProfile은 patch로 변경합니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Patch로 method 변경
  profile_image 필드가 없거나 null인 경우, 기존 프로필 이미지 삭제, 프로필 이미지 정보 업데이트 모두 일어나지 않습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
editProfile API 수행

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
만약 추후 프로필 이미지 삭제 기능이 추가된다면
null로 요청이 들어올 경우와, profile_image 필드가 없이 들어올 경우를 구분해서 로직을 수정해야 할 것 같습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #137 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
